### PR TITLE
Updated paper titles + last activity dates using ProVerBMate

### DIFF
--- a/Tools/2LS.md
+++ b/Tools/2LS.md
@@ -36,8 +36,7 @@ Model checker?? / Program analyser
 Repository: https://github.com/diffblue/2LS
 
 #### Last commit date:
-17 Nov 2022 (default branch)
-21 Nov 2022 (last activity)
+25 Jan 2023 (last activity)
 
 #### Last publication date:
 14 April 2018

--- a/Tools/ACL2.md
+++ b/Tools/ACL2.md
@@ -34,9 +34,8 @@ Related repository, seems to be where the ACL2 system authors develop ACL2: http
 Try ACL2 online: https://new.proofpad.org/
 
 #### Last commit date:
-acl2/acl2: 03 Dec 2022 (default branch)
-acl2-devel/acl2-devel: 20 Jul 2022 (default branch)
-03 Dec 2022 (last activity)
+acl2/acl2: 30 Mar 2023 (last activity)
+acl2-devel/acl2-devel: 23 Jul 2022 (last activity)
 
 #### Last publication date:
 2014

--- a/Tools/ADAC.md
+++ b/Tools/ADAC.md
@@ -33,7 +33,6 @@ Uses [[Yosys]], [[iprove]], [MiniSat](Solvers/SAT/MiniSat.md).
 https://github.com/imatyas/ADAC (this is linked in the paper but it contains very little useful information)
 
 #### Last commit date:
-02 Feb 2018 (default branch)
 02 Feb 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/AEON.md
+++ b/Tools/AEON.md
@@ -35,9 +35,8 @@ Client: https://github.com/sybila/biodivine-aeon-client
 Compute engine/server: https://github.com/sybila/biodivine-aeon-server
 
 #### Last commit date:
-sybila/biodivine-aeon-server: 19 May 2022 (default branch)
-sybila/biodivine-aeon-client: 25 Apr 2022 (default branch)
-11 Oct 2022 (last activity)
+sybila/biodivine-aeon-server: 07 Dec 2022 (last activity)
+sybila/biodivine-aeon-client: 06 Feb 2023 (last activity)
 
 #### Last publication date:
 24 July 2020

--- a/Tools/AIGEN.md
+++ b/Tools/AIGEN.md
@@ -35,7 +35,6 @@ Uses [ABC](Frameworks/ABC.md), [AIGER](../Formats/AIGER.md)
 Repository: https://github.com/mhdsakr/AIGEN-Tool
 
 #### Last commit date:
-02 Jun 2021 (default branch)
 02 Jun 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/AMUSIC.md
+++ b/Tools/AMUSIC.md
@@ -29,7 +29,6 @@ Tool for approximate counting of minimal unsatisfiable subsets of a given Boolea
 https://github.com/jar-ben/amusic
 
 #### Last commit date:
-22 Dec 2021 (default branch)
 22 Dec 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/APOET.md
+++ b/Tools/APOET.md
@@ -31,9 +31,7 @@ Repository (CAV '17 release): https://github.com/marcelosousa/poet/tree/RELEASE-
 Repository (of [POET](POET.md)): https://github.com/marcelosousa/poet
 
 #### Last commit date:
-marcelosousa/poet: 19 Oct 2018 (default branch)
-marcelosousa/poet: 19 Oct 2018 (default branch)
-19 Oct 2018 (last activity)
+marcelosousa/poet: 19 Oct 2018 (last activity)
 
 #### Last publication date:
 13 July 2017

--- a/Tools/AProVE.md
+++ b/Tools/AProVE.md
@@ -31,8 +31,7 @@ Repository (only has releases, not the code): https://github.com/aprove-develope
 Project page: http://aprove.informatik.rwth-aachen.de/
 
 #### Last commit date:
-30 Nov 2022 (default branch)
-30 Nov 2022 (last activity)
+04 Mar 2023 (last activity)
 
 #### Last publication date:
 August 2017

--- a/Tools/ATHOS.md
+++ b/Tools/ATHOS.md
@@ -36,7 +36,6 @@ The Github repository contains examples of configuration files and protocols.
 https://github.com/alexandrumc/async-to-sync-translation
 
 #### Last commit date:
-27 Jun 2019 (default branch)
 28 Apr 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/ATLAS(2).md
+++ b/Tools/ATLAS(2).md
@@ -34,8 +34,7 @@ Uses [Z3](Solvers/SMT/Z3.md)
 Repository: https://github.com/lorenzleutgeb/atlas/
 
 #### Last commit date:
-03 Nov 2022 (default branch)
-15 Nov 2022 (last activity)
+02 Mar 2023 (last activity)
 
 #### Last publication date:
 6 August 2022

--- a/Tools/Alive2.md
+++ b/Tools/Alive2.md
@@ -47,8 +47,7 @@ Repository: https://github.com/AliveToolkit/alive2
 Online version of `alice-tv` tool: https://alive2.llvm.org/ce/
 
 #### Last commit date:
-03 Dec 2022 (default branch)
-03 Dec 2022 (last activity)
+19 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/AliveInLean.md
+++ b/Tools/AliveInLean.md
@@ -37,7 +37,6 @@ https://sf.snu.ac.kr/aliveinlean/
 https://github.com/microsoft/aliveinlean
 
 #### Last commit date:
-13 Aug 2022 (default branch)
 13 Aug 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/AllRepair.md
+++ b/Tools/AllRepair.md
@@ -29,7 +29,6 @@ The proposed repairs are minimal in the number of changes applied to the program
 https://github.com/batchenRothenberg/AllRepair
 
 #### Last commit date:
-08 Mar 2021 (default branch)
 08 Mar 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Alloy.md
+++ b/Tools/Alloy.md
@@ -7,8 +7,7 @@ Project page: https://alloytools.org/
 Repository: https://github.com/AlloyTools/org.alloytools.alloy
 
 #### Last commit date:
-04 Nov 2022 (default branch)
-04 Nov 2022 (last activity)
+28 Mar 2023 (last activity)
 
 #### Meta
 :: Framework

--- a/Tools/BINSEC-RSE.md
+++ b/Tools/BINSEC-RSE.md
@@ -33,7 +33,6 @@ Artifact for CAV '21 paper: https://github.com/binsec/cav2021-artifacts
 Artifact for CAV '21 paper on Zenodo: https://zenodo.org/record/4721753
 
 #### Last commit date:
-26 Apr 2021 (default branch)
 26 Apr 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/BINSEC.md
+++ b/Tools/BINSEC.md
@@ -36,8 +36,7 @@ Reference manual: https://github.com/binsec/binsec/blob/master/doc/sse/reference
 Project page: https://binsec.github.io/
 
 #### Last commit date:
-09 Nov 2022 (default branch)
-09 Nov 2022 (last activity)
+14 Feb 2023 (last activity)
 
 #### Last publication date:
 

--- a/Tools/Batfish.md
+++ b/Tools/Batfish.md
@@ -40,8 +40,7 @@ https://www.batfish.org/
 https://github.com/batfish/batfish
 
 #### Last commit date:
-03 Dec 2022 (default branch)
-03 Dec 2022 (last activity)
+27 Mar 2023 (last activity)
 
 #### Last publication date:
 2015

--- a/Tools/CLEAR.md
+++ b/Tools/CLEAR.md
@@ -33,7 +33,6 @@ Debugging tool
 https://github.com/gbarbon/clear/
 
 #### Last commit date:
-21 Nov 2018 (default branch)
 21 Nov 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/COASTAL.md
+++ b/Tools/COASTAL.md
@@ -33,7 +33,6 @@ Repository: https://github.com/DeepseaPlatform/coastal/
 Project page: https://deepseaplatform.github.io/coastal/ (Note: this website seems to be unfinished)
 
 #### Last commit date:
-18 Sep 2022 (default branch)
 18 Sep 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/COLA.md
+++ b/Tools/COLA.md
@@ -1,4 +1,3 @@
-
 #### Name:
 COLA
 
@@ -36,6 +35,7 @@ COLA supports the following operations on Büchi automata:
 
 #### Last commit date:
 21 June 2022
+15 Jul 2022 (last activity)
 
 #### Last publication date:
 6 August 2022

--- a/Tools/CabPy.md
+++ b/Tools/CabPy.md
@@ -39,7 +39,6 @@ License: MIT License
 Repository: https://github.com/reactive-systems/cabpy
 
 #### Last commit date:
-28 May 2021 (default branch)
 28 May 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Cameleer.md
+++ b/Tools/Cameleer.md
@@ -34,8 +34,7 @@ Repository: https://github.com/ocaml-gospel/cameleer
 Artifact for CAV '21 paper: https://zenodo.org/record/4724119
 
 #### Last commit date:
-05 Sep 2022 (default branch)
-01 Dec 2022 (last activity)
+23 Jan 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Cervino.md
+++ b/Tools/Cervino.md
@@ -33,7 +33,6 @@ Artifact for CAV '21 paper: https://zenodo.org/record/4893262
 Repository: https://github.com/grayswandyr/cervino
 
 #### Last commit date:
-02 Jun 2021 (default branch)
 28 Oct 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/AGREE.md
+++ b/Tools/Checkers/AGREE.md
@@ -32,7 +32,6 @@ Project page: http://loonwerks.com/tools/agree.html
 Repository: https://github.com/loonwerks/AGREE
 
 #### Last commit date:
-29 Sep 2022 (default branch)
 29 Sep 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/AdamMC.md
+++ b/Tools/Checkers/AdamMC.md
@@ -41,7 +41,6 @@ https://github.com/adamtool/adammc
 https://figshare.com/articles/code/AdamMC_A_Model_Checker_for_Petri_Nets_with_Transits_against_Flow-LTL_Artifact_/11676171
 
 #### Last commit date:
-31 Oct 2021 (default branch)
 31 Oct 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/Attestor.md
+++ b/Tools/Checkers/Attestor.md
@@ -39,7 +39,6 @@ https://moves-rwth.github.io/attestor/
 Examples: https://github.com/moves-rwth/attestor-examples
 
 #### Last commit date:
-17 Dec 2021 (default branch)
 17 Dec 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/BtorMC.md
+++ b/Tools/Checkers/BtorMC.md
@@ -31,7 +31,6 @@ It is called a 'reference' bounded model checker in the paper.
 Seems to be included in the [Boolector](../Solvers/SMT/Boolector.md) repository: https://github.com/Boolector/boolector/tree/ad16fd1b47fdce57cc55ca5f1b2f4f7c95b2f631
 
 #### Last commit date:
-11 Oct 2022 (last activity)
 
 #### Last publication date:
 18 July 2018

--- a/Tools/Checkers/CBMC.md
+++ b/Tools/Checkers/CBMC.md
@@ -37,8 +37,7 @@ Repository: https://github.com/diffblue/cbmc
 Project page: https://www.cprover.org/cbmc/
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 18 July 2018

--- a/Tools/Checkers/CPAchecker.md
+++ b/Tools/Checkers/CPAchecker.md
@@ -43,8 +43,7 @@ Repository (mirror): https://github.com/sosy-lab/cpachecker
 Repository: https://svn.sosy-lab.org/software/cpachecker/trunk/
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
+23 Mar 2023 (last activity)
 
 #### Last publication date:
 November 2020

--- a/Tools/Checkers/DPU.md
+++ b/Tools/Checkers/DPU.md
@@ -27,7 +27,6 @@ Stateless model checker for C programs with POSIX threading
 Repository: https://github.com/cesaro/dpu
 
 #### Last commit date:
-18 Mar 2018 (default branch)
 07 Feb 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/Dartagnan.md
+++ b/Tools/Checkers/Dartagnan.md
@@ -31,8 +31,7 @@ Uses [Z3](../Solvers/SMT/Z3.md).
 Repository (also contains another tool): https://github.com/hernanponcedeleon/Dat3M
 
 #### Last commit date:
-30 Nov 2022 (default branch)
-02 Dec 2022 (last activity)
+28 Mar 2023 (last activity)
 
 #### Last publication date:
 23 March 2021

--- a/Tools/Checkers/DepthK.md
+++ b/Tools/Checkers/DepthK.md
@@ -36,7 +36,6 @@ Uses [CPAchecker](CPAchecker.md), [Ultimate Automizer](../Ultimate%20Automizer.m
 Repository: https://github.com/hbgit/depthk/
 
 #### Last commit date:
-09 Jan 2019 (default branch)
 20 Apr 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/Electrum Analyzer.md
+++ b/Tools/Checkers/Electrum Analyzer.md
@@ -41,15 +41,14 @@ Electrum examples: https://github.com/haslab/Electrum/wiki/Examples
 Project page: https://haslab.github.io/Electrum/
 
 #### Last commit date:
-haslab/Electrum: 08 Oct 2019 (default branch)
-haslab/Electrum2: 21 Apr 2021 (default branch)
-13 Sep 2021 (last activity)
+haslab/Electrum: 06 Jul 2021 (last activity)
+haslab/Electrum2: 30 Jan 2023 (last activity)
 
 #### Last publication date:
 3 September 2018
 
 #### List of related papers:
-https://doi.org/10.1145/3238147.3240475 (ASE '18)
+[The electrum analyzer: model checking relational first-order temporal specifications](https://doi.org/10.1145/3238147.3240475) (ASE '18)
 
 #### Related tools (tools mentioned or compared to in the paper):
 

--- a/Tools/Checkers/FOADA.md
+++ b/Tools/Checkers/FOADA.md
@@ -27,7 +27,6 @@ Uses [Z3](Tools/Solvers/SMT/Z3.md), [JavaSMT](Tools/Libraries/JavaSMT.md)
 Repository: https://github.com/cathiec/FOADA
 
 #### Last commit date:
-16 Feb 2020 (default branch)
 16 Feb 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/GenMC.md
+++ b/Tools/Checkers/GenMC.md
@@ -42,8 +42,7 @@ Project page: https://plv.mpi-sws.org/genmc/
 Repository: https://github.com/mpi-sws/genmc/
 
 #### Last commit date:
-22 Feb 2022 (default branch)
-22 Feb 2022 (last activity)
+26 Dec 2022 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Checkers/JBMC.md
+++ b/Tools/Checkers/JBMC.md
@@ -38,8 +38,6 @@ Project page: https://www.cprover.org/jbmc/
 Repository: https://github.com/diffblue/cbmc/tree/develop/jbmc (located in the [CBMC](CBMC.md) repository)
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
 
 #### Last publication date:
 4 April 2019

--- a/Tools/Checkers/JKind.md
+++ b/Tools/Checkers/JKind.md
@@ -39,7 +39,6 @@ Repository: https://github.com/loonwerks/jkind
 Project page: https://loonwerks.com/tools/jkind.html
 
 #### Last commit date:
-30 Sep 2022 (default branch)
 30 Sep 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/JPF.md
+++ b/Tools/Checkers/JPF.md
@@ -37,8 +37,7 @@ Repository: https://github.com/javapathfinder/jpf-core
 Wiki: https://github.com/javapathfinder/jpf-core/wiki
 
 #### Last commit date:
-03 Sep 2022 (default branch)
-03 Sep 2022 (last activity)
+28 Mar 2023 (last activity)
 
 #### Last publication date:
 4 April 2019

--- a/Tools/Checkers/JayHorn.md
+++ b/Tools/Checkers/JayHorn.md
@@ -36,7 +36,6 @@ Repository: https://github.com/jayhorn/jayhorn
 Project page: https://jayhorn.github.io/jayhorn/
 
 #### Last commit date:
-27 May 2021 (default branch)
 14 Dec 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/KIPRO2.md
+++ b/Tools/Checkers/KIPRO2.md
@@ -38,7 +38,6 @@ License: Apache-2.0 license
 Repository: https://github.com/moves-rwth/kipro2
 
 #### Last commit date:
-29 Jul 2021 (default branch)
 29 Jul 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/LLMC.md
+++ b/Tools/Checkers/LLMC.md
@@ -33,7 +33,6 @@ License: GNU General Public License 3.0
 Repository: https://github.com/bergfi/llmc
 
 #### Last commit date:
-01 Jun 2021 (default branch)
 01 Jun 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/MCHyper.md
+++ b/Tools/Checkers/MCHyper.md
@@ -39,7 +39,6 @@ Project page: https://www.react.uni-saarland.de/tools/mchyper/
 Repository: https://github.com/reactive-systems/MCHyper
 
 #### Last commit date:
-28 May 2021 (default branch)
 28 May 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/POET.md
+++ b/Tools/Checkers/POET.md
@@ -37,7 +37,6 @@ Repository: https://github.com/marcelosousa/poet
 Web page for CONCUR '15 paper: https://www.cs.ox.ac.uk/people/marcelo.sousa/poet/
 
 #### Last commit date:
-19 Oct 2018 (default branch)
 19 Oct 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/POMC.md
+++ b/Tools/Checkers/POMC.md
@@ -39,8 +39,7 @@ Repository: https://github.com/michiari/POMC]
 Artifact for CAV '21: https://zenodo.org/record/4723741
 
 #### Last commit date:
-20 Oct 2021 (default branch)
-23 Nov 2022 (last activity)
+21 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Checkers/PRISM-games.md
+++ b/Tools/Checkers/PRISM-games.md
@@ -39,8 +39,7 @@ Repository: https://github.com/prismmodelchecker/prism-games
 Support forum: https://groups.google.com/g/prismmodelchecker
 
 #### Last commit date:
-13 May 2022 (default branch)
-28 Jul 2022 (last activity)
+13 Feb 2023 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/Checkers/PRISM.md
+++ b/Tools/Checkers/PRISM.md
@@ -46,8 +46,7 @@ Project page: https://www.prismmodelchecker.org/
 Repository: https://github.com/prismmodelchecker/prism
 
 #### Last commit date:
-05 Nov 2022 (default branch)
-21 Nov 2022 (last activity)
+20 Mar 2023 (last activity)
 
 #### Last publication date:
 ?

--- a/Tools/Checkers/Pono.md
+++ b/Tools/Checkers/Pono.md
@@ -48,8 +48,7 @@ Pono was developed as the next generation of [CoSA](../CoSA.md) and was original
 Repository: https://github.com/upscale-project/pono
 
 #### Last commit date:
-26 Oct 2022 (default branch)
-26 Oct 2022 (last activity)
+25 Feb 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Checkers/PrIC3.md
+++ b/Tools/Checkers/PrIC3.md
@@ -37,7 +37,6 @@ It is called a 'prototypical implementation' in the CAV '20 paper.
 Repository: https://github.com/moves-rwth/PrIC3
 
 #### Last commit date:
-30 Sep 2020 (default branch)
 30 Sep 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/QuIP.md
+++ b/Tools/Checkers/QuIP.md
@@ -35,7 +35,6 @@ Uses [RABIT](../RABIT.md) to check language inclusion and [Reduce](../Reduce.md)
 Possibly the following repository from the first author's github: https://github.com/suguman/QIP/ (*not linked in the paper or on the first author's website*)
 
 #### Last commit date:
-26 Sep 2018 (default branch)
 26 Sep 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/SPAN.md
+++ b/Tools/Checkers/SPAN.md
@@ -30,7 +30,6 @@ Uses [[KISS]], [[AKISS]], [Maude](../../Formats/Maude.md), [Apfloat](../Librarie
 Repository: https://github.com/bauer-matthews/SPAN
 
 #### Last commit date:
-20 Apr 2018 (default branch)
 22 May 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/STAMINA.md
+++ b/Tools/Checkers/STAMINA.md
@@ -34,8 +34,7 @@ Uses [PRISM](PRISM.md)
 Repository: https://github.com/fluentverification/stamina
 
 #### Last commit date:
-03 Nov 2022 (default branch)
-03 Nov 2022 (last activity)
+01 Mar 2023 (last activity)
 
 #### Last publication date:
 12 July 2019

--- a/Tools/Checkers/STLmc.md
+++ b/Tools/Checkers/STLmc.md
@@ -1,4 +1,3 @@
-
 #### Name:
 STLmc
 
@@ -37,6 +36,7 @@ It uses SMT solvers such as [Z3](../../Tools/Solvers/SMT/Z3.md), [Yices](../../T
 
 #### Last commit date:
 2 February 2023
+13 Feb 2023 (last activity)
 
 #### Last publication date:
 7 August 2022

--- a/Tools/Checkers/STMC.md
+++ b/Tools/Checkers/STMC.md
@@ -31,7 +31,6 @@ Project page: https://nima-roohi.github.io/STMC/
 Repository: https://github.com/nima-roohi/STMC
 
 #### Last commit date:
-13 Jan 2020 (default branch)
 06 Apr 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/SeaHorn.md
+++ b/Tools/Checkers/SeaHorn.md
@@ -31,8 +31,7 @@ Project page: https://seahorn.github.io/
 Repository: https://github.com/seahorn/seahorn
 
 #### Last commit date:
-05 Nov 2022 (default branch)
-30 Nov 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 24 November 2018

--- a/Tools/Checkers/SimpleCAR.md
+++ b/Tools/Checkers/SimpleCAR.md
@@ -33,7 +33,6 @@ Repository: https://github.com/lijwen2748/simplecar/
 Project page: http://temporallogic.org/research/CAV18/
 
 #### Last commit date:
-18 Jul 2022 (default branch)
 09 Nov 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/SolCMC.md
+++ b/Tools/Checkers/SolCMC.md
@@ -41,9 +41,7 @@ Shipped with Ethereum Foundation's Solidity compiler. Used to be called SMTCheck
 - Repository: https://github.com/ethereum/solidity/tree/develop/libsolidity/formal
 
 #### Last commit date:
-leonardoalt/cav_2022_artifact: 07 Jun 2022 (default branch)
-ethereum/solidity: 02 Dec 2022 (default branch)
-03 Dec 2022 (last activity)
+leonardoalt/cav_2022_artifact: 07 Jun 2022 (last activity)
 
 #### Last publication date:
 2022

--- a/Tools/Checkers/Storm.md
+++ b/Tools/Checkers/Storm.md
@@ -52,8 +52,7 @@ Some benchmarks from papers are available via http://www.stormchecker.org/benchm
 Repository: https://github.com/moves-rwth/storm
 
 #### Last commit date:
-20 Nov 2022 (default branch)
-23 Nov 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 6 July 2021

--- a/Tools/Checkers/SymDIVINE.md
+++ b/Tools/Checkers/SymDIVINE.md
@@ -32,7 +32,6 @@ The repo is archived and no longer maintained. It is now integrated into [DIVINE
 Repository: https://github.com/paradise-fi/SymDIVINE
 
 #### Last commit date:
-19 Mar 2019 (default branch)
 19 Mar 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/Checkers/Ultimate Taipan.md
+++ b/Tools/Checkers/Ultimate Taipan.md
@@ -42,16 +42,15 @@ Try online: https://monteverdi.informatik.uni-freiburg.de/tomcat/Website/?ui=int
 Repository (of the Ultimate framework): https://github.com/ultimate-pa/ultimate/
 
 #### Last commit date:
-03 Dec 2022 (default branch)
-03 Dec 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 17 April 2020
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-030-45237-7_32 (TACAS '20, Competition contribution)
-https://doi.org/10.1007/978-3-319-89963-3_31 (TACAS '18, Competition contribution)
-https://doi.org/10.1007/978-3-662-54580-5_31 (TACAS '17, Competition contribution)
+[Ultimate Taipan with Symbolic Interpretation and Fluid Abstractions](https://doi.org/10.1007/978-3-030-45237-7_32) (TACAS '20, Competition contribution)
+[Ultimate Taipan with Dynamic Block Encoding](https://doi.org/10.1007/978-3-319-89963-3_31) (TACAS '18, Competition contribution)
+[Ultimate Taipan: Trace Abstraction and Abstract Interpretation](https://doi.org/10.1007/978-3-662-54580-5_31) (TACAS '17, Competition contribution)
 
 #### Related tools (tools mentioned or compared to in the paper):
 

--- a/Tools/CloudFORMAL.md
+++ b/Tools/CloudFORMAL.md
@@ -30,7 +30,6 @@ Encodes AWS CloudFormation templates into Description Logic models.
 Repository: https://github.com/claudiacauli/CloudFORMAL
 
 #### Last commit date:
-24 Jun 2022 (default branch)
 30 Sep 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/CoSA.md
+++ b/Tools/CoSA.md
@@ -51,7 +51,6 @@ License: Modified BSD (3-clause BSD) license
 Repository: https://github.com/cristian-mattarei/CoSA
 
 #### Last commit date:
-27 Oct 2020 (default branch)
 27 Oct 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Code2Inv.md
+++ b/Tools/Code2Inv.md
@@ -31,7 +31,6 @@ Given a verification task and proof checker as input, it automatically learns a 
 Repository: https://github.com/PL-ML/code2inv
 
 #### Last commit date:
-26 Jan 2021 (default branch)
 26 Jan 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Consensus Verifier.md
+++ b/Tools/Consensus Verifier.md
@@ -35,7 +35,7 @@ Project page: http://www.infsec.ethz.ch/research/software/consl-verifier
 13 July 2017
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-319-63390-9_12 (CAV '17)
+[Cutoff Bounds for Consensus Algorithms](https://doi.org/10.1007/978-3-319-63390-9_12) (CAV '17)
 
 #### Related tools (tools mentioned or compared to in the paper):
 

--- a/Tools/CountMUST.md
+++ b/Tools/CountMUST.md
@@ -31,7 +31,6 @@ Uses [[GANAK]], [[RIME]] and [UWrMaxSat](Solvers/UWrMaxSat.md).
 Repository: https://github.com/jar-ben/exactMUSCounter
 
 #### Last commit date:
-26 Apr 2021 (default branch)
 11 Jun 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/DEEPSEC.md
+++ b/Tools/DEEPSEC.md
@@ -31,9 +31,8 @@ Repository: https://github.com/DeepSec-prover/deepsec
 Repository for the UI: https://github.com/DeepSec-prover/deepsec_ui
 
 #### Last commit date:
-DeepSec-prover/deepsec: 23 Jul 2020 (default branch)
-DeepSec-prover/deepsec_ui: 03 May 2020 (default branch)
-10 Nov 2022 (last activity)
+DeepSec-prover/deepsec: 01 Mar 2023 (last activity)
+DeepSec-prover/deepsec_ui: 10 Dec 2022 (last activity)
 
 #### Last publication date:
 4 February 2020

--- a/Tools/DIGITS.md
+++ b/Tools/DIGITS.md
@@ -30,7 +30,6 @@ License: MIT
 Paper doesn't seem to link to the implementation. Link found on first author's webpage: https://github.com/sedrews/digits
 
 #### Last commit date:
-14 Oct 2019 (default branch)
 14 Oct 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/DIVINE.md
+++ b/Tools/DIVINE.md
@@ -36,7 +36,6 @@ Project page: https://divine.fi.muni.cz/index.html
 Repository: https://github.com/paradise-fi/divine (mirror)
 
 #### Last commit date:
-21 Mar 2021 (default branch)
 21 Mar 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/DLV.md
+++ b/Tools/DLV.md
@@ -34,7 +34,6 @@ License: GNU General Public License v3.0
 Repository: https://github.com/verideep/dlv 
 
 #### Last commit date:
-05 Feb 2018 (default branch)
 05 Feb 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/DNNV.md
+++ b/Tools/DNNV.md
@@ -37,8 +37,7 @@ Documentation: https://dnnv.readthedocs.io/
 Artifact for CAV '21 paper: https://doi.org/10.5281/zenodo.4883626
 
 #### Last commit date:
-02 Aug 2022 (default branch)
-06 Sep 2022 (last activity)
+27 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Dafny.md
+++ b/Tools/Dafny.md
@@ -38,8 +38,7 @@ Documentation: https://dafny-lang.github.io/dafny/
 Repository: https://github.com/dafny-lang/dafny
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-03 Dec 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 2018

--- a/Tools/Daisy.md
+++ b/Tools/Daisy.md
@@ -50,7 +50,6 @@ Repository: https://github.com/malyzajko/daisy
 Documentation: https://github.com/malyzajko/daisy/blob/master/doc/documentation.md
 
 #### Last commit date:
-26 Apr 2022 (default branch)
 26 Apr 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/DetLP.md
+++ b/Tools/DetLP.md
@@ -33,7 +33,6 @@ Uses [GLPSOL](Solvers/GLPSOL.md), [Reduce](Reduce.md).
 Repository: https://github.com/suguman/DetLP
 
 #### Last commit date:
-07 Oct 2017 (default branch)
 07 Oct 2017 (last activity)
 
 #### Last publication date:

--- a/Tools/Diffy.md
+++ b/Tools/Diffy.md
@@ -34,7 +34,6 @@ Artifact for CAV '21: https://figshare.com/articles/software/Diffy_Inductive_Rea
 Artifact for CAV '21, repository: https://github.com/divyeshunadkat/diffy-artifact
 
 #### Last commit date:
-29 Apr 2021 (default branch)
 05 Nov 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/DryVR.md
+++ b/Tools/DryVR.md
@@ -41,9 +41,8 @@ Successor/version 2.0 of DryVR: https://github.com/qibolun/DryVR_0.2 (last commi
 Successor of version 2.0 of DryVR: https://gitlab.engr.illinois.edu/dryvrgroup/dryvrtool
 
 #### Last commit date:
-qibolun/DryVR_0.2: 27 Sep 2021 (default branch)
-qibolun/DryVR: 27 Sep 2021 (default branch)
-27 Sep 2021 (last activity)
+qibolun/DryVR_0.2: 27 Sep 2021 (last activity)
+qibolun/DryVR: 27 Sep 2021 (last activity)
 
 #### Last publication date:
 13 July 2017

--- a/Tools/EAHyper.md
+++ b/Tools/EAHyper.md
@@ -40,7 +40,6 @@ Repository: https://github.com/reactive-systems/eahyper
 Try EAHyper online: https://www.react.uni-saarland.de/tools/online/EAHyper/
 
 #### Last commit date:
-18 Jul 2018 (default branch)
 18 Jul 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/ERAN.md
+++ b/Tools/ERAN.md
@@ -33,8 +33,7 @@ License: Apache-2.0
 Repository: https://github.com/eth-sri/eran
 
 #### Last commit date:
-30 May 2022 (default branch)
-30 May 2022 (last activity)
+27 Jan 2023 (last activity)
 
 #### Last publication date:
 2021

--- a/Tools/ESBMC.md
+++ b/Tools/ESBMC.md
@@ -45,8 +45,7 @@ Repository: https://github.com/esbmc/esbmc
 Project page: http://esbmc.org/
 
 #### Last commit date:
-01 Dec 2022 (default branch)
-01 Dec 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 8 September 2021

--- a/Tools/EXIST.md
+++ b/Tools/EXIST.md
@@ -31,8 +31,7 @@ Exist will execute the program multiple times on a set of input states. It uses 
 Repository: https://github.com/JialuJialu/Exist
 
 #### Last commit date:
-12 Jun 2022 (default branch)
-12 Jun 2022 (last activity)
+03 Feb 2023 (last activity)
 
 #### Last publication date:
 2022

--- a/Tools/Endicheck.md
+++ b/Tools/Endicheck.md
@@ -33,7 +33,6 @@ License: GPL
 Repository: https://github.com/rkapl/endicheck
 
 #### Last commit date:
-30 Jan 2020 (default branch)
 30 Jan 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/EntropyEstimation.md
+++ b/Tools/EntropyEstimation.md
@@ -1,4 +1,3 @@
-
 #### Name:
 EntropyEstimation
 
@@ -35,12 +34,13 @@ Uses [[GANAK]] for model counting queries and [[SPUR]] for sampling queries.
 
 #### Last commit date:
 4 June 2022
+04 Jun 2022 (last activity)
 
 #### Last publication date:
 7 August 2022
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-031-13185-1_18 (CAV 2022)
+[A Scalable Shannon Entropy Estimator](https://doi.org/10.1007/978-3-031-13185-1_18) (CAV 2022)
 
 #### Related tools (tools mentioned or compared to in the paper):
 -

--- a/Tools/FGL.md
+++ b/Tools/FGL.md
@@ -33,8 +33,6 @@ FGL is integrated into [ACL2](ACL2.md).
 Repository: https://github.com/acl2/acl2/tree/master/books/centaur/fgl
 
 #### Last commit date:
-03 Dec 2022 (default branch)
-03 Dec 2022 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/FORKLIFT.md
+++ b/Tools/FORKLIFT.md
@@ -1,4 +1,3 @@
-
 #### Name:
 FORKLIFT
 
@@ -33,6 +32,7 @@ FORKLIFT is an inclusion checker for Büchi automata.
 
 #### Last commit date:
 7 June 2022
+07 Jun 2022 (last activity)
 
 #### Last publication date:
 6 August 2022

--- a/Tools/FRET.md
+++ b/Tools/FRET.md
@@ -1,4 +1,3 @@
-
 #### Name:
 FRET (Formal Requirements Elicitation tool)
 
@@ -32,6 +31,7 @@ Repository: https://github.com/NASA-SW-VnV/fret
 
 #### Last commit date:
 25 January 2023
+25 Jan 2023 (last activity)
 
 #### Last publication date:
 6 August 2022

--- a/Tools/ForeSee.md
+++ b/Tools/ForeSee.md
@@ -32,8 +32,7 @@ License: GPL-3.0
 Artifact for CAV '21 paper: https://github.com/choshina/ForeSee
 
 #### Last commit date:
-30 May 2021 (default branch)
-10 Aug 2022 (last activity)
+14 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Forester.md
+++ b/Tools/Forester.md
@@ -37,7 +37,6 @@ Project page: https://www.fit.vutbr.cz/research/groups/verifit/tools/forester/
 Repository: https://github.com/martinhruska/forester/
 
 #### Last commit date:
-21 Jul 2013 (default branch)
 29 Oct 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/Frameworks/ABC.md
+++ b/Tools/Frameworks/ABC.md
@@ -50,8 +50,7 @@ https://people.eecs.berkeley.edu/~alanmi/abc/
 https://github.com/berkeley-abc/abc
 
 #### Last commit date:
-29 Nov 2022 (default branch)
-29 Nov 2022 (last activity)
+26 Mar 2023 (last activity)
 
 #### List of related papers:
 [ABC: An Academic Industrial-Strength Verification Tool](https://doi.org/10.1007/978-3-642-14295-6_5) (CAV '10)

--- a/Tools/Frameworks/Adam.md
+++ b/Tools/Frameworks/Adam.md
@@ -25,8 +25,7 @@ Github group/project: https://github.com/adamtool/
 Repository: https://github.com/adamtool/adam
 
 #### Last commit date:
-04 May 2022 (default branch)
-04 May 2022 (last activity)
+adamtool/adam: 04 May 2022 (last activity)
 
 #### List of related papers:
 [Adam: Causality-Based Synthesis of Distributed Systems](https://doi.org/10.1007/978-3-319-21690-4_25) (CAV '15)

--- a/Tools/Frameworks/Boogie.md
+++ b/Tools/Frameworks/Boogie.md
@@ -32,8 +32,7 @@ https://github.com/boogie-org/boogie
 https://boogie-docs.readthedocs.io/en/latest/ (Documentation)
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Frameworks/ILAng.md
+++ b/Tools/Frameworks/ILAng.md
@@ -27,7 +27,6 @@ Repository: https://github.com/Bo-Yuan-Huang/ILAng
 Project page/documentation: https://bo-yuan-huang.gitbook.io/ilang/
 
 #### Last commit date:
-22 Apr 2022 (default branch)
 22 Apr 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Frameworks/UCLID5.md
+++ b/Tools/Frameworks/UCLID5.md
@@ -35,6 +35,7 @@ UCLID5 can also be used to synthesize function bodies for user-declared function
 
 #### Last commit date:
 18 January 2023
+27 Mar 2023 (last activity)
 
 #### Last publication date:
 7 August 2022

--- a/Tools/Frameworks/UPPAAL.md
+++ b/Tools/Frameworks/UPPAAL.md
@@ -27,7 +27,6 @@ GitHub account with documentation and some libraries: https://github.com/UPPAALM
 
 #### Last commit date:
 
-
 #### Last publication date:
 2021
 

--- a/Tools/FreqTerm.md
+++ b/Tools/FreqTerm.md
@@ -27,8 +27,6 @@ Uses [Spacer](Solvers/Spacer.md)3, [µZ](Solvers/µZ.md) [[AE-VAL]], [Z3](Solver
 Repository: https://github.com/grigoryfedyukovich/aeval/tree/term
 
 #### Last commit date:
-10 Feb 2018 (default branch)
-03 Oct 2022 (last activity)
 
 #### Last publication date:
 18 July 2018

--- a/Tools/GANAK.md
+++ b/Tools/GANAK.md
@@ -30,6 +30,7 @@ Repository: https://github.com/meelgroup/ganak
 
 #### Last commit date:
 18 November 2022
+16 Mar 2023 (last activity)
 
 #### Last publication date:
 10 August 2019

--- a/Tools/GDVB.md
+++ b/Tools/GDVB.md
@@ -31,8 +31,7 @@ Uses [[R4V]] and [DNNV](DNNV.md).
 Repository: https://github.com/edwardxu0/GDVB
 
 #### Last commit date:
-22 Jul 2020 (default branch)
-21 Nov 2022 (last activity)
+25 Mar 2023 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/GPUDrano.md
+++ b/Tools/GPUDrano.md
@@ -34,7 +34,6 @@ GPUDrano tries to find uncoalesced accesses. Uncoalesced memory accesses occur w
 Repository: https://github.com/upenn-acg/gpudrano-static-analysis_v1.0
 
 #### Last commit date:
-16 Nov 2018 (default branch)
 16 Nov 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/GRASShopper.md
+++ b/Tools/GRASShopper.md
@@ -42,8 +42,7 @@ Repository: https://github.com/wies/grasshopper
 Project page: https://cs.nyu.edu/~wies/software/grasshopper/
 
 #### Last commit date:
-20 May 2021 (default branch)
-24 Dec 2021 (last activity)
+02 Mar 2023 (last activity)
 
 #### Last publication date:
 2014

--- a/Tools/Gillian.md
+++ b/Tools/Gillian.md
@@ -36,8 +36,7 @@ Project page: https://gillianplatform.github.io/
 Repository: https://github.com/GillianPlatform/Gillian
 
 #### Last commit date:
-01 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Gobra.md
+++ b/Tools/Gobra.md
@@ -39,9 +39,8 @@ Zulip organization for discussions: https://gobra.zulipchat.com/login/
 Tutorial: https://github.com/viperproject/gobra/blob/master/docs/tutorial.md
 
 #### Last commit date:
-viperproject/gobra: 02 Dec 2022 (default branch)
-viperproject/gobra-ide: 03 Dec 2022 (default branch)
-03 Dec 2022 (last activity)
+viperproject/gobra: 30 Mar 2023 (last activity)
+viperproject/gobra-ide: 30 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Hemiola.md
+++ b/Tools/Hemiola.md
@@ -1,4 +1,3 @@
-
 #### Name:
 Hemiola
 
@@ -39,12 +38,13 @@ The framework seems to provide the following options:
 
 #### Last commit date:
 4 May 2022
+07 May 2022 (last activity)
 
 #### Last publication date:
 6 August 2022
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-031-13188-2_16 (CAV 2022)
+[Hemiola: A DSL and Verification Tools to Guide Design and Proof of Hierarchical Cache-Coherence Protocols](https://doi.org/10.1007/978-3-031-13188-2_16) (CAV 2022)
 
 #### Related tools (tools mentioned or compared to in the paper):
 Rule-based hardware language: [[Bluespec]]

--- a/Tools/HolBA.md
+++ b/Tools/HolBA.md
@@ -41,8 +41,7 @@ It has the following tools:
 Repository: https://github.com/kth-step/HolBA
 
 #### Last commit date:
-29 Sep 2022 (default branch)
-02 Dec 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 8 September 2020

--- a/Tools/HyPA.md
+++ b/Tools/HyPA.md
@@ -46,6 +46,7 @@ Repository: https://github.com/hypa-tool/hypa
 
 #### Last commit date:
 26 August 2022
+26 Aug 2022 (last activity)
 
 #### Last publication date:
 7 August 2022

--- a/Tools/HybridSynchAADL.md
+++ b/Tools/HybridSynchAADL.md
@@ -49,7 +49,6 @@ Project page: https://hybridsynchaadl.github.io/
 Repository: https://github.com/hybridsynchaadl/HybridSynchAADL
 
 #### Last commit date:
-05 May 2021 (default branch)
 05 May 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Hylaa.md
+++ b/Tools/Hylaa.md
@@ -36,8 +36,7 @@ Repository: https://github.com/stanleybak/hylaa
 Project page: http://stanleybak.com/hylaa
 
 #### Last commit date:
-15 Jun 2021 (default branch)
-15 Jun 2021 (last activity)
+21 Mar 2023 (last activity)
 
 #### Last publication date:
 13 July 2017

--- a/Tools/IAM Access Analyzer.md
+++ b/Tools/IAM Access Analyzer.md
@@ -43,7 +43,7 @@ Project page: https://aws.amazon.com/iam/
 14 July 2020
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-030-53288-8_9 (CAV '20)
+[Stratified Abstraction of Access Control Policies](https://doi.org/10.1007/978-3-030-53288-8_9) (CAV '20)
 
 #### Related tools (tools mentioned or compared to in the paper):
 

--- a/Tools/IMITATOR.md
+++ b/Tools/IMITATOR.md
@@ -47,8 +47,7 @@ Project page: https://www.imitator.fr/
 Repository: https://github.com/imitator-model-checker/imitator/
 
 #### Last commit date:
-04 Oct 2022 (default branch)
-02 Dec 2022 (last activity)
+17 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/InterpChecker.md
+++ b/Tools/InterpChecker.md
@@ -33,7 +33,6 @@ False negatives may occur for programs with recursive functions since recursive 
 Repository: https://github.com/duanzhao-dz/interpchecker
 
 #### Last commit date:
-22 Nov 2017 (default branch)
 22 Nov 2017 (last activity)
 
 #### Last publication date:

--- a/Tools/Isla.md
+++ b/Tools/Isla.md
@@ -38,8 +38,7 @@ Repository: https://github.com/rems-project/isla
 Documentation: https://github.com/rems-project/isla/blob/master/doc/axiomatic.adoc
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
+06 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Ivy.md
+++ b/Tools/Ivy.md
@@ -40,9 +40,8 @@ Repository (linked on project page): https://github.com/kenmcmil/ivy
 Old repository (the original, now archived repository, links to the repository above as the new one): https://github.com/microsoft/ivy
 
 #### Last commit date:
-kenmcmil/ivy: 13 Oct 2022 (default branch)
-microsoft/ivy: 04 Sep 2020 (default branch)
-13 Oct 2022 (last activity)
+kenmcmil/ivy: 30 Jan 2023 (last activity)
+microsoft/ivy: 06 Jan 2021 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/JDart.md
+++ b/Tools/JDart.md
@@ -34,9 +34,8 @@ Documentation (from original repository): https://github.com/psycopaths/jdart/wi
 Repository: https://github.com/tudo-aqua/jdart
 
 #### Last commit date:
-tudo-aqua/jdart: 26 Nov 2019 (default branch)
-psycopaths/jdart: 17 Sep 2018 (default branch)
-04 May 2022 (last activity)
+tudo-aqua/jdart: 04 May 2022 (last activity)
+psycopaths/jdart: 02 Jun 2019 (last activity)
 
 #### Last publication date:
 17 April 2020

--- a/Tools/KLEE.md
+++ b/Tools/KLEE.md
@@ -34,8 +34,7 @@ Repository: https://github.com/klee/klee/
 Project page: https://klee.github.io/
 
 #### Last commit date:
-25 Jun 2022 (default branch)
-28 Nov 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 2 June 2020

--- a/Tools/LCTD.md
+++ b/Tools/LCTD.md
@@ -38,7 +38,6 @@ http://users.cse.aalto.fi/osaariki/lctd-svcomp/
 https://github.com/OlliSaarikivi/benchexec/blob/master/benchexec/tools/lctd.py
 
 #### Last commit date:
-02 Nov 2015 (default branch)
 02 Nov 2015 (last activity)
 
 #### Last publication date:

--- a/Tools/LEGION.md
+++ b/Tools/LEGION.md
@@ -1,4 +1,3 @@
-
 #### Name:
 LEGION
 
@@ -35,6 +34,7 @@ Uses [Z3](../../Tools/Solvers/SMT/Z3.md) to solve SMT queries.
 
 #### Last commit date:
 6 May 2022 (branch: legion)
+22 Mar 2023 (last activity)
 
 #### Last publication date:
 7 August 2022

--- a/Tools/LEVEL-UP.md
+++ b/Tools/LEVEL-UP.md
@@ -37,7 +37,6 @@ LEVEL-UP is a prototype built on top of [Storm](../../Tools/Checkers/Storm.md).
 - Repository: https://github.com/sjunges/level-up
 
 #### Last commit date:
-15 Aug 2022 (default branch)
 15 Aug 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/LLVM2SMT.md
+++ b/Tools/LLVM2SMT.md
@@ -19,7 +19,6 @@ LLVM to SMT
 https://github.com/termite-analyser/llvm2smt
 
 #### Last commit date:
-21 Apr 2018 (default branch)
 21 Apr 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/Libraries/APRON.md
+++ b/Tools/Libraries/APRON.md
@@ -32,8 +32,7 @@ http://apron.cri.ensmp.fr/library/
 https://github.com/antoinemine/apron
 
 #### Last commit date:
-14 Oct 2022 (default branch)
-10 Nov 2022 (last activity)
+10 Mar 2023 (last activity)
 
 #### Last publication date:
 2009

--- a/Tools/Libraries/Apfloat.md
+++ b/Tools/Libraries/Apfloat.md
@@ -17,8 +17,7 @@ https://github.com/mtommila/apfloat (for Java)
 http://www.apfloat.org/apfloat/ (for C++)
 
 #### Last commit date:
-08 Oct 2022 (default branch)
-24 Nov 2022 (last activity)
+24 Mar 2023 (last activity)
 
 #### Meta
 :: Java

--- a/Tools/Libraries/Automata.md
+++ b/Tools/Libraries/Automata.md
@@ -31,7 +31,6 @@ License: MIT License
 Repository: https://github.com/AutomataDotNet/Automata
 
 #### Last commit date:
-30 May 2020 (default branch)
 21 Jul 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Libraries/CIVL.md
+++ b/Tools/Libraries/CIVL.md
@@ -25,8 +25,7 @@ Error for any properties that are violated, including error traces.
 Code (part of [[Boogie]]): https://github.com/boogie-org/boogie
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/Libraries/CUDD.md
+++ b/Tools/Libraries/CUDD.md
@@ -12,8 +12,7 @@ CUDD: CU Decision Diagram package
 Repository: https://github.com/ivmai/cudd
 
 #### Last commit date:
-01 Jan 2016 (default branch)
-21 Jan 2016 (last activity)
+07 Feb 2023 (last activity)
 
 #### Meta
 :: PV0 :: a C package for manipulating decision diagrams

--- a/Tools/Libraries/Ceramist.md
+++ b/Tools/Libraries/Ceramist.md
@@ -29,7 +29,6 @@ Repository: https://github.com/certichain/ceramist
 Artifact: https://zenodo.org/record/3749474
 
 #### Last commit date:
-13 Apr 2020 (default branch)
 13 Apr 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Libraries/Crab.md
+++ b/Tools/Libraries/Crab.md
@@ -29,8 +29,7 @@ Own CFG-based intermediate representation (CrabIR)
 Repository: https://github.com/seahorn/crab
 
 #### Last commit date:
-06 Nov 2022 (default branch)
-07 Nov 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 

--- a/Tools/Libraries/DG.md
+++ b/Tools/Libraries/DG.md
@@ -35,8 +35,7 @@ License: MIT license
 Repository: https://github.com/mchalupa/dg
 
 #### Last commit date:
-17 May 2022 (default branch)
-29 Jun 2022 (last activity)
+05 Jan 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Libraries/EMTST.md
+++ b/Tools/Libraries/EMTST.md
@@ -30,7 +30,6 @@ License: GPL-3.0
 Repository (including case studies): https://github.com/emtst/emtst-proof
 
 #### Last commit date:
-15 Jun 2021 (default branch)
 15 Jun 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Libraries/JConstraints.md
+++ b/Tools/Libraries/JConstraints.md
@@ -22,7 +22,7 @@ JConstraints
 #### Last publication date:
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-030-22348-9_19
+[JConstraints: A Library for Working with Logic Expressions in Java](https://doi.org/10.1007/978-3-030-22348-9_19)
 
 #### Related tools (tools mentioned or compared to in the paper):
 

--- a/Tools/Libraries/Java Ranger.md
+++ b/Tools/Libraries/Java Ranger.md
@@ -35,14 +35,13 @@ Repository: https://github.com/vaibhavbsharma/java-ranger
 Project page: https://vaibhavbsharma.github.io/java-ranger/
 
 #### Last commit date:
-07 Dec 2021 (default branch)
-01 Dec 2022 (last activity)
+20 Dec 2022 (last activity)
 
 #### Last publication date:
 -
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-030-45237-7_27 (TACAS '20)
+[Java Ranger at SV-COMP 2020 (Competition Contribution)](https://doi.org/10.1007/978-3-030-45237-7_27) (TACAS '20)
 
 #### Related tools (tools mentioned or compared to in the paper):
 [Symbolic PathFinder](Symbolic%20PathFinder)

--- a/Tools/Libraries/JavaSMT.md
+++ b/Tools/Libraries/JavaSMT.md
@@ -22,14 +22,13 @@ Uses [[Boolector]], [[CVC4]], [[CVC5]], [[MathSAT]]5, [[OptiMathSAT]], [[Princes
 https://github.com/sosy-lab/java-smt
 
 #### Last commit date:
-16 Nov 2022 (default branch)
-27 Nov 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 2021
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-030-81688-9_9
+[JavaSMT 3: Interacting with SMT Solvers in Java](https://doi.org/10.1007/978-3-030-81688-9_9)
 
 #### Related tools (tools mentioned or compared to in the paper):
 

--- a/Tools/Libraries/LearnLib.md
+++ b/Tools/Libraries/LearnLib.md
@@ -21,7 +21,6 @@ https://learnlib.de/
 https://github.com/Learnlib/learnlib
 
 #### Last commit date:
-12 Sep 2022 (default branch)
 12 Sep 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Libraries/MPFR.md
+++ b/Tools/Libraries/MPFR.md
@@ -26,7 +26,7 @@ https://www.mpfr.org/
 #### Last publication date:
 
 #### List of related papers:
-https://doi.org/10.1145/1236463.1236468
+[MPFR](https://doi.org/10.1145/1236463.1236468)
 
 #### Related tools (tools mentioned or compared to in the paper):
 

--- a/Tools/Libraries/PySMT.md
+++ b/Tools/Libraries/PySMT.md
@@ -23,8 +23,7 @@ It supports the following solvers: [MathSAT](../Solvers/SMT/MathSAT.md), [Z3](..
 Repository: https://github.com/pysmt/pysmt
 
 #### Last commit date:
-28 Oct 2022 (default branch)
-28 Oct 2022 (last activity)
+04 Mar 2023 (last activity)
 
 #### Last publication date:
 

--- a/Tools/Libraries/ROLL.md
+++ b/Tools/Libraries/ROLL.md
@@ -42,7 +42,6 @@ Project page: http://iscasmc.ios.ac.cn/roll/
 Repository: https://github.com/ISCAS-PMC/roll-library
 
 #### Last commit date:
-12 Jul 2021 (default branch)
 12 Jul 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Libraries/SVPALib.md
+++ b/Tools/Libraries/SVPALib.md
@@ -28,9 +28,8 @@ https://github.com/lorisdanto/symbolicautomata (main repo)
 https://github.com/lorisdanto/automatark (benchmarks)
 
 #### Last commit date:
-lorisdanto/symbolicautomata: 17 Aug 2022 (default branch)
-lorisdanto/automatark: 24 Jun 2018 (default branch)
-17 Aug 2022 (last activity)
+lorisdanto/symbolicautomata: 17 Aug 2022 (last activity)
+lorisdanto/automatark: 19 Apr 2022 (last activity)
 
 #### Last publication date:
 

--- a/Tools/Libraries/Smt-Switch.md
+++ b/Tools/Libraries/Smt-Switch.md
@@ -23,8 +23,7 @@ Interface
 https://github.com/stanford-centaur/smt-switch
 
 #### Last commit date:
-03 Dec 2022 (default branch)
-03 Dec 2022 (last activity)
+14 Mar 2023 (last activity)
 
 #### Last publication date:
 https://doi.org/10.1007/978-3-030-80223-3_26 (SAT 2021)

--- a/Tools/Libraries/SyReNN.md
+++ b/Tools/Libraries/SyReNN.md
@@ -32,8 +32,7 @@ A DNN is piecewise-linear if its input domain can be precisely partitioned into 
 Repository: https://github.com/95616ARG/SyReNN
 
 #### Last commit date:
-10 Sep 2021 (default branch)
-22 Nov 2022 (last activity)
+20 Mar 2023 (last activity)
 
 #### Last publication date:
 2021

--- a/Tools/Libraries/UDBM.md
+++ b/Tools/Libraries/UDBM.md
@@ -24,8 +24,7 @@ https://github.com/UPPAALModelChecker/UDBM
 https://github.com/UPPAALModelChecker/UDBM/wiki
 
 #### Last commit date:
-28 Nov 2022 (default branch)
-02 Dec 2022 (last activity)
+07 Dec 2022 (last activity)
 
 #### Last publication date:
 

--- a/Tools/Libraries/py-metric-temporal-logic.md
+++ b/Tools/Libraries/py-metric-temporal-logic.md
@@ -21,8 +21,7 @@ py-metric-temporal-logic
 https://github.com/mvcisback/py-metric-temporal-logic
 
 #### Last commit date:
-24 Sep 2022 (default branch)
-24 Sep 2022 (last activity)
+20 Feb 2023 (last activity)
 
 #### Last publication date:
 

--- a/Tools/Libraries/pyuppaal.md
+++ b/Tools/Libraries/pyuppaal.md
@@ -25,7 +25,6 @@ Project page: https://github.com/bencaldwell/pyuppaal
 Old project page: https://launchpad.net/pyuppaal
 
 #### Last commit date:
-08 Sep 2015 (default branch)
 08 Sep 2015 (last activity)
 
 #### Last publication date:

--- a/Tools/LoopInvGen.md
+++ b/Tools/LoopInvGen.md
@@ -32,7 +32,6 @@ Uses [Escher](Synthesiser/Escher.md), [Z3](Solvers/SMT/Z3.md)
 Repository: https://github.com/SaswatPadhi/LoopInvGen
 
 #### Last commit date:
-23 Apr 2020 (default branch)
 23 Jan 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/MOVEC.md
+++ b/Tools/MOVEC.md
@@ -28,7 +28,6 @@ Project page: https://drzchen.github.io/projects/movec/
 Repository: https://github.com/drzchen/movec
 
 #### Last commit date:
-10 Dec 2021 (default branch)
 10 Dec 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Map2Check.md
+++ b/Tools/Map2Check.md
@@ -46,7 +46,6 @@ Project page: https://map2check.github.io/
 Repository: https://github.com/hbgit/Map2Check
 
 #### Last commit date:
-13 Feb 2020 (default branch)
 13 Nov 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Mapping Synthesis Tool.md
+++ b/Tools/Mapping Synthesis Tool.md
@@ -31,14 +31,13 @@ Note the authors themselves call this a "prototype implementation" and it doesn'
 Repository: https://github.com/eskang/MappingSynthesisTool
 
 #### Last commit date:
-03 Feb 2019 (default branch)
 02 May 2019 (last activity)
 
 #### Last publication date:
 12 July 2019
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-030-25540-4_12 (CAV 2019)
+[Automated Synthesis of Secure Platform Mappings](https://doi.org/10.1007/978-3-030-25540-4_12) (CAV 2019)
 
 #### Related tools (tools mentioned or compared to in the paper):
 -

--- a/Tools/Marabou.md
+++ b/Tools/Marabou.md
@@ -41,9 +41,8 @@ Repository (unsure what the difference is): https://github.com/NeuralNetworkVeri
 Project page: https://neuralnetworkverification.github.io/
 
 #### Last commit date:
-NeuralNetworkVerification/Marabou: 29 Nov 2022 (default branch)
-guykatzz/Marabou: 24 Sep 2021 (default branch)
-02 Dec 2022 (last activity)
+NeuralNetworkVerification/Marabou: 28 Mar 2023 (last activity)
+guykatzz/Marabou: 09 Oct 2021 (last activity)
 
 #### Last publication date:
 23 March 2021

--- a/Tools/MeMin.md
+++ b/Tools/MeMin.md
@@ -33,7 +33,6 @@ Project page: http://embedded.cs.uni-saarland.de/MeMin.php
 Repository: https://github.com/andreas-abel/MeMin
 
 #### Last commit date:
-08 May 2018 (default branch)
 08 May 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/Metatools/MachSMT.md
+++ b/Tools/Metatools/MachSMT.md
@@ -33,7 +33,6 @@ Artifact TACAS '21: https://zenodo.org/record/4458699
 Repository (Artifact for TACAS '21): https://github.com/MachSMT/MachSMT
 
 #### Last commit date:
-28 Nov 2022 (default branch)
 29 Nov 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Metatools/Murxla.md
+++ b/Tools/Metatools/Murxla.md
@@ -1,4 +1,3 @@
-
 #### Name:
 Murxla
 
@@ -42,6 +41,7 @@ Murxla also provides options to replay and minimize traces.
 
 #### Last commit date:
 24 February 2023
+14 Mar 2023 (last activity)
 
 #### Last publication date:
 6 August 2022

--- a/Tools/Metatools/PeSCo.md
+++ b/Tools/Metatools/PeSCo.md
@@ -40,7 +40,6 @@ PeSCo is integrated in [CPAchecker](../Checkers/CPAchecker.md).
 Repository (fork of CPAChecker into which PeSCo is integrated): https://github.com/cedricrupb/cpachecker
 
 #### Last commit date:
-23 Nov 2022 (default branch)
 23 Nov 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Metatools/ddSMT.md
+++ b/Tools/Metatools/ddSMT.md
@@ -34,8 +34,7 @@ Documentation: https://ddsmt.readthedocs.io/
 Repository: https://github.com/ddsmt/ddsmt
 
 #### Last commit date:
-19 Sep 2022 (default branch)
-19 Sep 2022 (last activity)
+12 Jan 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Metatools/tAIlor.md
+++ b/Tools/Metatools/tAIlor.md
@@ -31,7 +31,6 @@ Repository: https://github.com/Practical-Formal-Methods/tailor
 Artifact for CAV '21: https://zenodo.org/record/4719604
 
 #### Last commit date:
-24 Nov 2021 (default branch)
 24 Nov 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/MoGym.md
+++ b/Tools/MoGym.md
@@ -1,4 +1,3 @@
-
 #### Name:
 MoGym
 
@@ -36,6 +35,7 @@ Based on [[Momba]]
 
 #### Last commit date:
 28 November 2022
+28 Nov 2022 (last activity)
 
 #### Last publication date:
 6 August 2022

--- a/Tools/Montre.md
+++ b/Tools/Montre.md
@@ -33,7 +33,6 @@ License: GPL-3.0
 Repository: https://github.com/doganulus/montre
 
 #### Last commit date:
-21 Oct 2019 (default branch)
 21 Oct 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/Move Prover.md
+++ b/Tools/Move Prover.md
@@ -34,14 +34,13 @@ The Move Prover seems to be an auto-active verifier though this is not mentioned
 Repository (has a different name but is linked in the paper): https://github.com/diem/diem
 
 #### Last commit date:
-02 Aug 2021 (default branch)
-02 Dec 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 14 July 2020
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-030-53288-8_7 (CAV '20)
+[The Move Prover](https://doi.org/10.1007/978-3-030-53288-8_7) (CAV '20)
 
 #### Related tools (tools mentioned or compared to in the paper):
 

--- a/Tools/MuVal.md
+++ b/Tools/MuVal.md
@@ -33,8 +33,7 @@ License: Apache-2.0
 Repository?: https://github.com/hiroshi-unno/coar (should include [MuVal](MuVal.md) and [PCSat](Solvers/PCSat.md))
 
 #### Last commit date:
-11 May 2021 (default branch)
-11 May 2021 (last activity)
+27 Feb 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/NNV.md
+++ b/Tools/NNV.md
@@ -37,8 +37,7 @@ The repository calls it a "Matlab Toolbox for Neural Network Verification". It r
 Repository: https://github.com/verivital/nnv
 
 #### Last commit date:
-26 Sep 2022 (default branch)
-22 Nov 2022 (last activity)
+03 Feb 2023 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/NOPE.md
+++ b/Tools/NOPE.md
@@ -34,7 +34,6 @@ There exist SyGuS problems for which the algorithm cannot prove unrealizability 
 Repository (not linked in paper, found via author's webpage): https://github.com/Herbping/Nope
 
 #### Last commit date:
-27 Mar 2020 (default branch)
 27 Mar 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Nagini.md
+++ b/Tools/Nagini.md
@@ -35,8 +35,7 @@ Information about the specification language: https://github.com/marcoeilers/nag
 Artifact of CAV 2021 paper: https://zenodo.org/record/4724854
 
 #### Last commit date:
-18 Feb 2022 (default branch)
-11 Aug 2022 (last activity)
+29 Jan 2023 (last activity)
 
 #### Last publication date:
 18 July 2018

--- a/Tools/Nidhugg.md
+++ b/Tools/Nidhugg.md
@@ -38,8 +38,7 @@ License: GPL v3.0
 Repository: https://github.com/nidhugg/nidhugg
 
 #### Last commit date:
-01 Nov 2022 (default branch)
-01 Nov 2022 (last activity)
+03 Feb 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Not-verifiers/ANTLR.md
+++ b/Tools/Not-verifiers/ANTLR.md
@@ -27,8 +27,7 @@ Project page: https://www.antlr.org/
 Repository: https://github.com/antlr/antlr4
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 

--- a/Tools/Not-verifiers/Automata Tutor.md
+++ b/Tools/Not-verifiers/Automata Tutor.md
@@ -34,7 +34,7 @@ https://automata.model.in.tum.de/
 14 July 2020
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-030-53291-8_1
+[Automata Tutor v3](https://doi.org/10.1007/978-3-030-53291-8_1)
 
 #### Related tools (tools mentioned or compared to in the paper):
 Autotool, JFLAP, Gradience

--- a/Tools/Not-verifiers/CoreIR.md
+++ b/Tools/Not-verifiers/CoreIR.md
@@ -8,7 +8,6 @@ On the github repository it is described as "An LLVM-style hardware compiler wit
 Repository: https://github.com/rdaly525/coreir
 
 #### Last commit date:
-27 Jun 2022 (default branch)
 27 Jun 2022 (last activity)
 
 #### Meta

--- a/Tools/Not-verifiers/Dice.md
+++ b/Tools/Not-verifiers/Dice.md
@@ -23,8 +23,7 @@ Language
 https://github.com/SHoltzen/dice
 
 #### Last commit date:
-22 Apr 2022 (default branch)
-04 Nov 2022 (last activity)
+07 Dec 2022 (last activity)
 
 #### Last publication date:
 

--- a/Tools/Oink.md
+++ b/Tools/Oink.md
@@ -31,7 +31,6 @@ Uses the [[Lace]] work-stealing framework.
 Repository: https://www.github.com/trolando/oink
 
 #### Last commit date:
-04 Sep 2022 (default branch)
 04 Sep 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Origami.md
+++ b/Tools/Origami.md
@@ -32,8 +32,7 @@ The goal of Origami is **scalability**, they want to be able to analyze large ne
 Repository (? linked on author's webpage): https://github.com/NetworkVerification/nv
 
 #### Last commit date:
-22 Nov 2022 (default branch)
-28 Nov 2022 (last activity)
+20 Feb 2023 (last activity)
 
 #### Last publication date:
 12 July 2019

--- a/Tools/PAF.md
+++ b/Tools/PAF.md
@@ -28,7 +28,6 @@ License: MIT
 Repository: https://github.com/soarlab/paf
 
 #### Last commit date:
-07 Dec 2021 (default branch)
 07 Dec 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/PAYNT.md
+++ b/Tools/PAYNT.md
@@ -33,8 +33,7 @@ Repository: https://github.com/gargantophob/synthesis
 CAV '21 artifact: https://doi.org/10.5281/zenodo.4726056
 
 #### Last commit date:
-30 Nov 2022 (default branch)
-01 Dec 2022 (last activity)
+13 Feb 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/PEREGRiNN.md
+++ b/Tools/PEREGRiNN.md
@@ -37,7 +37,6 @@ License: MIT, however it relies on [[Gurobi]] which is a commercial tool. It is 
 Repository: https://github.com/rcpsl/PeregriNN
 
 #### Last commit date:
-05 May 2021 (default branch)
 09 Jul 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/PIRK.md
+++ b/Tools/PIRK.md
@@ -38,8 +38,7 @@ From the CAV 2020 paper (emphasis our own): "To the best of our knowledge, PIRK 
 https://github.com/mkhaled87/pFaces-PIRK
 
 #### Last commit date:
-26 Dec 2021 (default branch)
-26 Dec 2021 (last activity)
+10 Mar 2023 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/PLearn.md
+++ b/Tools/PLearn.md
@@ -31,7 +31,6 @@ The idea behind the tool is that SyGuS tools are sensitive to the choice of gram
 Artefact of CAV '19 paper: https://github.com/SaswatPadhi/2019_CAV_Artifact_100
 
 #### Last commit date:
-07 May 2019 (default branch)
 07 May 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/POR-SE.md
+++ b/Tools/POR-SE.md
@@ -35,7 +35,6 @@ Repository: https://github.com/por-se/por-se
 Extended version of CAV '20 paper: https://arxiv.org/pdf/2005.06688.pdf
 
 #### Last commit date:
-15 Dec 2021 (default branch)
 16 Dec 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/POROUS.md
+++ b/Tools/POROUS.md
@@ -35,7 +35,6 @@ Online web interface: https://porous.mpi-sws.org/
 Repository: https://github.com/davidjpurser/porous-tool
 
 #### Last commit date:
-28 Jan 2022 (default branch)
 28 Jan 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/PRISM-PSY.md
+++ b/Tools/PRISM-PSY.md
@@ -39,7 +39,6 @@ Project page: http://www.prismmodelchecker.org/psy/
 Repository: https://github.com/Palmik/prism-pse
 
 #### Last commit date:
-08 Aug 2014 (default branch)
 05 Dec 2015 (last activity)
 
 #### Last publication date:

--- a/Tools/PRODIGY.md
+++ b/Tools/PRODIGY.md
@@ -1,4 +1,3 @@
-
 #### Name:
 PRODIGY: PRObability DIstributions via GeneratingfunctionologY
 
@@ -28,6 +27,7 @@ The tool Probably (https://github.com/Philipp15b/Probably) forms the basis of th
 
 #### Last commit date:
 30 June 2022
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 7 August 2022

--- a/Tools/PROVER.md
+++ b/Tools/PROVER.md
@@ -32,7 +32,6 @@ Uses [Gurobi](Solvers/Gurobi.md)
 Repository: https://github.com/eth-sri/prover
 
 #### Last commit date:
-29 Jun 2021 (default branch)
 29 Jun 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Pastis.md
+++ b/Tools/Pastis.md
@@ -37,7 +37,6 @@ Pastis also automatically generates proof certificates of the validity of its bo
 Repository: https://github.com/academic-archive/cav17-pastis
 
 #### Last commit date:
-01 Jul 2021 (default branch)
 01 Jul 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Petit Poucet.md
+++ b/Tools/Petit Poucet.md
@@ -28,14 +28,13 @@ Explanation graph of the user-defined function.
 Repository: https://github.com/liflab/petitpoucet
 
 #### Last commit date:
-18 Nov 2022 (default branch)
-18 Nov 2022 (last activity)
+16 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-030-81688-9_24 (CAV '21)
+[Foundations of Fine-Grained Explainability](https://doi.org/10.1007/978-3-030-81688-9_24) (CAV '21)
 
 #### Related tools (tools mentioned or compared to in the paper):
 

--- a/Tools/Pinaka.md
+++ b/Tools/Pinaka.md
@@ -31,7 +31,6 @@ The TACAS '19 paper mentions that Pinaka is the result of the rewriting and refa
 Repository: https://github.com/sbjoshi/Pinaka
 
 #### Last commit date:
-19 Oct 2020 (default branch)
 19 Oct 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Pithya.md
+++ b/Tools/Pithya.md
@@ -38,9 +38,8 @@ Repository GUI: https://github.com/sybila/pithya-gui
 Repository: https://github.com/sybila/pithya-core
 
 #### Last commit date:
-sybila/pithya-core: 16 Aug 2022 (default branch)
-sybila/pithya-gui: 15 Dec 2020 (default branch)
-16 Aug 2022 (last activity)
+sybila/pithya-core: 16 Aug 2022 (last activity)
+sybila/pithya-gui: 15 Dec 2020 (last activity)
 
 #### Last publication date:
 13 July 2017

--- a/Tools/PredatorHP.md
+++ b/Tools/PredatorHP.md
@@ -44,7 +44,6 @@ Project page: https://www.fit.vutbr.cz/research/groups/verifit/tools/predator-hp
 Repository: https://github.com/versokova/predatorhp
 
 #### Last commit date:
-20 Nov 2019 (default branch)
 20 Nov 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/Premise.md
+++ b/Tools/Premise.md
@@ -38,7 +38,6 @@ Repository: https://github.com/monitoring-MDPs/premise
 Artifact for CAV '21 paper: https://doi.org/10.5281/zenodo.4724623
 
 #### Last commit date:
-28 Apr 2021 (default branch)
 28 Apr 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Provers/Coq.md
+++ b/Tools/Provers/Coq.md
@@ -26,8 +26,7 @@ Repository: https://github.com/coq/coq
 Project page: https://coq.inria.fr/
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 

--- a/Tools/Provers/HOL.md
+++ b/Tools/Provers/HOL.md
@@ -37,8 +37,7 @@ Repository: https://github.com/HOL-Theorem-Prover/HOL
 Guidebook/manual: https://hol-theorem-prover.org/guidebook/
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
+23 Mar 2023 (last activity)
 
 #### Last publication date:
 

--- a/Tools/Provers/Lean.md
+++ b/Tools/Provers/Lean.md
@@ -29,8 +29,7 @@ Documentation: https://leanprover.github.io/lean4/doc/
 Theorem proving in Lean 4 tutorial: https://leanprover.github.io/theorem_proving_in_lean4/
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-03 Dec 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 5 July 2021

--- a/Tools/Provers/Vampire.md
+++ b/Tools/Provers/Vampire.md
@@ -36,8 +36,7 @@ Project page (old one?): http://www.vprover.org/
 Repository: https://github.com/vprover/vampire
 
 #### Last commit date:
-21 Nov 2022 (default branch)
-01 Dec 2022 (last activity)
+28 Mar 2023 (last activity)
 
 #### Last publication date:
 2017

--- a/Tools/RABIT.md
+++ b/Tools/RABIT.md
@@ -33,7 +33,6 @@ Project page: http://www.languageinclusion.org/doku.php?id=tools#rabit_and_reduc
 Repository: https://github.com/ISCAS-PMC/RABIT
 
 #### Last commit date:
-09 Jan 2019 (default branch)
 09 Jan 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/RINO.md
+++ b/Tools/RINO.md
@@ -1,4 +1,3 @@
-
 #### Name:
 RINO
 
@@ -37,6 +36,7 @@ Repository: https://github.com/cosynus-lix/RINO
 
 #### Last commit date:
 22 September 2022
+22 Sep 2022 (last activity)
 
 #### Last publication date:
 7 August 2022

--- a/Tools/Ranker.md
+++ b/Tools/Ranker.md
@@ -1,4 +1,3 @@
-
 #### Name:
 Ranker
 
@@ -32,6 +31,7 @@ Ranker supports several types of $\omega$-automata:
 
 #### Last commit date:
 30 December 2022
+30 Dec 2022 (last activity)
 
 #### Last publication date:
 6 August 2022

--- a/Tools/ReVerC.md
+++ b/Tools/ReVerC.md
@@ -34,7 +34,6 @@ License: MIT
 Repository: https://github.com/msr-quarc/ReVerC
 
 #### Last commit date:
-05 Mar 2019 (default branch)
 05 Mar 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/Reduce.md
+++ b/Tools/Reduce.md
@@ -36,7 +36,6 @@ By default Reduce will reduce Büchi automata. You can switch to NFA semantics b
 Repository (Reduce is packaged with [RABIT](RABIT.md)): https://github.com/ISCAS-PMC/RABIT
 
 #### Last commit date:
-09 Jan 2019 (default branch)
 09 Jan 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/Rubicon.md
+++ b/Tools/Rubicon.md
@@ -35,7 +35,6 @@ Artifact for CAV '21: https://zenodo.org/record/4726264
 Repository: https://github.com/sjunges/rubicon
 
 #### Last commit date:
-10 Jun 2021 (default branch)
 10 Jun 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/SCHMIT.md
+++ b/Tools/SCHMIT.md
@@ -35,7 +35,6 @@ Uses [Gurobi](Solvers/Gurobi.md), [[Javassist]], [[Scipy]]
 Repository: https://github.com/cuplv/Schmit
 
 #### Last commit date:
-12 Nov 2021 (default branch)
 12 Nov 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/SLURF.md
+++ b/Tools/SLURF.md
@@ -1,4 +1,3 @@
-
 #### Name:
 SLURF
 
@@ -41,6 +40,7 @@ The prediction regions can depict how the uncertainty in the input influences th
 
 #### Last commit date:
 22 September 2022
+21 Nov 2022 (last activity)
 
 #### Last publication date:
 7 August 2022

--- a/Tools/SMTCoq.md
+++ b/Tools/SMTCoq.md
@@ -27,8 +27,7 @@ Project page: https://smtcoq.github.io/
 Repository: https://github.com/smtcoq/smtcoq
 
 #### Last commit date:
-17 Oct 2022 (default branch)
-28 Nov 2022 (last activity)
+21 Mar 2023 (last activity)
 
 #### Last publication date:
 13 July 2017

--- a/Tools/SPARK.md
+++ b/Tools/SPARK.md
@@ -41,8 +41,7 @@ Repository: https://github.com/AdaCore/spark2014
 Tutorial: https://learn.adacore.com/courses/intro-to-spark/index.html
 
 #### Last commit date:
-28 Nov 2022 (default branch)
-02 Dec 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 19 December 2020

--- a/Tools/SPF.md
+++ b/Tools/SPF.md
@@ -32,8 +32,7 @@ License: Apache License v2.0
 Repository: https://github.com/SymbolicPathFinder/jpf-symbc
 
 #### Last commit date:
-05 Oct 2022 (default branch)
-28 Nov 2022 (last activity)
+20 Jan 2023 (last activity)
 
 #### Last publication date:
 4 April 2019

--- a/Tools/SPIN.md
+++ b/Tools/SPIN.md
@@ -38,8 +38,7 @@ Repository: https://github.com/nimble-code/Spin
 Project page: https://spinroot.com/
 
 #### Last commit date:
-14 Oct 2022 (default branch)
-14 Oct 2022 (last activity)
+28 Mar 2023 (last activity)
 
 #### Last publication date:
 2012

--- a/Tools/SRM.md
+++ b/Tools/SRM.md
@@ -29,7 +29,6 @@ License: MIT
 Repository: https://github.com/AutomataDotNet/srm
 
 #### Last commit date:
-15 Apr 2021 (default branch)
 23 Sep 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/STLInspector.md
+++ b/Tools/STLInspector.md
@@ -33,7 +33,6 @@ License: Apache License 2.0
 Repository: https://github.com/STLInspector/STLInspector
 
 #### Last commit date:
-30 Sep 2019 (default branch)
 30 Sep 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/Safety Analysis of Weakly-Hard Systems.md
+++ b/Tools/Safety Analysis of Weakly-Hard Systems.md
@@ -37,14 +37,13 @@ SAW computes a tight estimation of the safe initial set for infinite-time safety
 Repository: https://github.com/551100kk/SAW
 
 #### Last commit date:
-29 Jan 2020 (default branch)
 29 Jan 2020 (last activity)
 
 #### Last publication date:
 14 July 2020
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-030-53288-8_26
+[SAW: A Tool for Safety Analysis of Weakly-Hard Systems](https://doi.org/10.1007/978-3-030-53288-8_26)
 
 #### Related tools (tools mentioned or compared to in the paper):
 -

--- a/Tools/Sample.md
+++ b/Tools/Sample.md
@@ -36,7 +36,6 @@ Uses [APRON](Libraries/APRON.md) for numerical analysis.
 Repository: https://github.com/viperproject/sample
 
 #### Last commit date:
-05 Jun 2020 (default branch)
 05 Jun 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Scam-V.md
+++ b/Tools/Scam-V.md
@@ -36,8 +36,7 @@ Repository: https://github.com/kth-step/HolBA
 Tutorial: https://github.com/kth-step/HolBA/wiki/HolBA-SCAM-V-tutorial
 
 #### Last commit date:
-29 Sep 2022 (default branch)
-02 Dec 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/Seminator.md
+++ b/Tools/Seminator.md
@@ -1,4 +1,3 @@
-
 A tool for semi-determinization and complementaiton of Transition-based generalised Büchi automata (TGBAs).
 
 #### Name:
@@ -32,7 +31,6 @@ Transforms transition-based generalised Büchi automata (TGBAs) into equivalent 
 Repository: https://github.com/mklokocka/seminator
 
 #### Last commit date:
-12 Mar 2021 (default branch)
 08 Jul 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Software Analysis Workbench.md
+++ b/Tools/Software Analysis Workbench.md
@@ -39,14 +39,13 @@ Tutorial: https://saw.galois.com/tutorial.html
 Manual: https://saw.galois.com/manual.html
 
 #### Last commit date:
-22 Nov 2022 (default branch)
-03 Dec 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 8 November 2016
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-319-48869-1_5 (VSTTE 2016)
+[Constructing Semantic Models of Programs with the Software Analysis Workbench](https://doi.org/10.1007/978-3-319-48869-1_5) (VSTTE 2016)
 
 #### Related tools (tools mentioned or compared to in the paper):
 -

--- a/Tools/Solvers/Alloy Analyzer.md
+++ b/Tools/Solvers/Alloy Analyzer.md
@@ -30,8 +30,7 @@ Project page: https://alloytools.org/
 Repository: https://github.com/AlloyTools/org.alloytools.alloy
 
 #### Last commit date:
-04 Nov 2022 (default branch)
-04 Nov 2022 (last activity)
+28 Mar 2023 (last activity)
 
 #### Last publication date:
 

--- a/Tools/Solvers/CADET.md
+++ b/Tools/Solvers/CADET.md
@@ -28,7 +28,6 @@ CADET is a 2QBF (Quantified Boolean formulas with forall-exists quantifier alter
 Repository: https://github.com/MarkusRabe/cadet
 
 #### Last commit date:
-27 Jan 2021 (default branch)
 27 Jan 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Solvers/CAQE.md
+++ b/Tools/Solvers/CAQE.md
@@ -32,7 +32,6 @@ Project page: https://www.react.uni-saarland.de/tools/caqe/
 Repository: https://github.com/ltentrup/caqe
 
 #### Last commit date:
-06 Jun 2022 (default branch)
 06 Jun 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Solvers/CoqQFBV.md
+++ b/Tools/Solvers/CoqQFBV.md
@@ -32,8 +32,7 @@ It takes a `QF_BV` query in [SMT-LIB](../../Formats/SMT-LIB.md) format. This is 
 Repository: https://github.com/fmlab-iis/coq-qfbv
 
 #### Last commit date:
-28 Nov 2022 (default branch)
-28 Nov 2022 (last activity)
+06 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Solvers/FreqHorn.md
+++ b/Tools/Solvers/FreqHorn.md
@@ -29,9 +29,7 @@ Repository: https://github.com/freqhorn/freqhorn
 Other repository that is also linked: https://github.com/grigoryfedyukovich/aeval/tree/rnd
 
 #### Last commit date:
-grigoryfedyukovich/aeval: 09 Aug 2022 (default branch)
-freqhorn/freqhorn: 09 Aug 2022 (default branch)
-26 Nov 2022 (last activity)
+freqhorn/freqhorn: 26 Nov 2022 (last activity)
 
 #### Last publication date:
 12 July 2019

--- a/Tools/Solvers/GSpacer.md
+++ b/Tools/Solvers/GSpacer.md
@@ -26,7 +26,6 @@ Extension of [Spacer](Spacer.md), a CHC (Constrained Horn Clause) solver in [Z3]
 Repository: https://github.com/hgvk94/z3/tree/gspacer-cav-ae
 
 #### Last commit date:
-23 Nov 2022 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/Solvers/OptiMathSAT.md
+++ b/Tools/Solvers/OptiMathSAT.md
@@ -37,7 +37,6 @@ Project page: https://optimathsat.disi.unitn.it/
 Repository with examples using OptiMathSAT's Python API: https://github.com/PatrickTrentin88/omt_python_examples
 
 #### Last commit date:
-12 Aug 2020 (default branch)
 12 Aug 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Solvers/PCSat.md
+++ b/Tools/Solvers/PCSat.md
@@ -38,8 +38,7 @@ Note: the authors sometimes call PCSat a (second-order) constraint solver
 Repository (contains [MuVal](../MuVal.md) and PCSat): https://github.com/hiroshi-unno/coar
 
 #### Last commit date:
-11 May 2021 (default branch)
-11 May 2021 (last activity)
+27 Feb 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Solvers/QuAbS.md
+++ b/Tools/Solvers/QuAbS.md
@@ -34,7 +34,6 @@ Project page: https://www.react.uni-saarland.de/tools/quabs/
 Repository: https://github.com/ltentrup/quabs
 
 #### Last commit date:
-24 Oct 2020 (default branch)
 24 Oct 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Solvers/SAT/CaDiCaL.md
+++ b/Tools/Solvers/SAT/CaDiCaL.md
@@ -29,6 +29,7 @@ Repository: https://github.com/arminbiere/cadical
 
 #### Last commit date:
 17 Aug 2022
+11 Mar 2023 (last activity)
 
 #### Last publication date:
 2019

--- a/Tools/Solvers/SAT/CryptoMiniSat.md
+++ b/Tools/Solvers/SAT/CryptoMiniSat.md
@@ -30,8 +30,7 @@ Project page: https://www.msoos.org/cryptominisat5/
 Repository: https://github.com/msoos/cryptominisat/
 
 #### Last commit date:
-06 Nov 2022 (default branch)
-06 Nov 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 2009

--- a/Tools/Solvers/SAT/Kissat.md
+++ b/Tools/Solvers/SAT/Kissat.md
@@ -29,7 +29,6 @@ Project page: http://fmv.jku.at/kissat/
 Repository: https://github.com/arminbiere/kissat
 
 #### Last commit date:
-07 Jul 2022 (default branch)
 07 Jul 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Solvers/SAT/Lingeling.md
+++ b/Tools/Solvers/SAT/Lingeling.md
@@ -30,7 +30,6 @@ Project page: http://fmv.jku.at/lingeling/
 Repository: https://github.com/arminbiere/lingeling
 
 #### Last commit date:
-15 May 2022 (default branch)
 15 May 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Solvers/SAT/ParaFROST.md
+++ b/Tools/Solvers/SAT/ParaFROST.md
@@ -30,9 +30,8 @@ ParaFROST Repository: https://github.com/muhos/ParaFROST
 CBMC Interface Repository: https://github.com/muhos/gpu4bmc
 
 #### Last commit date:
-muhos/gpu4bmc: 14 Mar 2022 (default branch)
-muhos/ParaFROST: 23 Nov 2022 (default branch)
-23 Nov 2022 (last activity)
+muhos/gpu4bmc: 14 Mar 2022 (last activity)
+muhos/ParaFROST: 29 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Solvers/SAT/plingeling.md
+++ b/Tools/Solvers/SAT/plingeling.md
@@ -31,7 +31,6 @@ Project page: http://fmv.jku.at/lingeling/
 Repository (also contains [Lingeling](Lingeling.md) and [[Treengeling]]): https://github.com/arminbiere/lingeling
 
 #### Last commit date:
-15 May 2022 (default branch)
 15 May 2022 (last activity)
 
 #### List of related papers:

--- a/Tools/Solvers/SMT/Alt-Ergo.md
+++ b/Tools/Solvers/SMT/Alt-Ergo.md
@@ -37,8 +37,7 @@ Documentation: https://ocamlpro.github.io/alt-ergo/index.html
 Try online: https://try-alt-ergo.ocamlpro.com/
 
 #### Last commit date:
-29 Nov 2022 (default branch)
-01 Dec 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 13 July 2017

--- a/Tools/Solvers/SMT/Bitwuzla.md
+++ b/Tools/Solvers/SMT/Bitwuzla.md
@@ -24,8 +24,7 @@ Project page: https://bitwuzla.github.io/
 Documentation: https://bitwuzla.github.io/docs/index.html
 
 #### Last commit date:
-07 Oct 2022 (default branch)
-03 Dec 2022 (last activity)
+28 Mar 2023 (last activity)
 
 #### Last publication date:
 

--- a/Tools/Solvers/SMT/Boolector.md
+++ b/Tools/Solvers/SMT/Boolector.md
@@ -32,8 +32,7 @@ Project page: https://boolector.github.io/
 Documentation: https://boolector.github.io/docs/index.html
 
 #### Last commit date:
-11 Oct 2022 (default branch)
-11 Oct 2022 (last activity)
+10 Jan 2023 (last activity)
 
 #### Last publication date:
 July 2019

--- a/Tools/Solvers/SMT/CVC4.md
+++ b/Tools/Solvers/SMT/CVC4.md
@@ -30,7 +30,6 @@ Repository: https://github.com/CVC4/CVC4-archived
 Project page: https://cvc4.github.io/
 
 #### Last commit date:
-05 May 2021 (default branch)
 06 May 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Solvers/SMT/MonoSAT.md
+++ b/Tools/Solvers/SMT/MonoSAT.md
@@ -36,7 +36,6 @@ Repository: https://github.com/sambayless/monosat
 Tutorial showing how to use MonoSAT in Python: https://github.com/sambayless/monosat/blob/master/TUTORIAL.md
 
 #### Last commit date:
-16 Jun 2022 (default branch)
 16 Jun 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Solvers/SMT/Q3B.md
+++ b/Tools/Solvers/SMT/Q3B.md
@@ -30,8 +30,7 @@ Uses [CUDD](../../Libraries/CUDD.md), [ANTLR](../../Not-verifiers/ANTLR.md), [SM
 Repository: https://github.com/martinjonas/Q3B
 
 #### Last commit date:
-06 Mar 2019 (default branch)
-02 Jul 2022 (last activity)
+26 Feb 2023 (last activity)
 
 #### Last publication date:
 12 July 2019

--- a/Tools/Solvers/SMT/Reluplex.md
+++ b/Tools/Solvers/SMT/Reluplex.md
@@ -33,7 +33,6 @@ Verifying DNNs is difficult because it is beyond the reach of general-purpose to
 Artifact of CAV '17 paper: https://github.com/guykatzz/ReluplexCav2017
 
 #### Last commit date:
-08 Jul 2020 (default branch)
 08 Jul 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Solvers/SMT/SMTInterpol.md
+++ b/Tools/Solvers/SMT/SMTInterpol.md
@@ -31,8 +31,7 @@ Try online: https://ultimate.informatik.uni-freiburg.de/smtinterpol/online/
 Repository: https://github.com/ultimate-pa/smtinterpol
 
 #### Last commit date:
-24 Nov 2022 (default branch)
-24 Nov 2022 (last activity)
+20 Mar 2023 (last activity)
 
 #### Last publication date:
 12 January 2021

--- a/Tools/Solvers/SMT/Yices.md
+++ b/Tools/Solvers/SMT/Yices.md
@@ -31,8 +31,7 @@ Project page: https://yices.csl.sri.com/
 Repository: https://github.com/SRI-CSL/yices2
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
+28 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Solvers/SMT/Z3.md
+++ b/Tools/Solvers/SMT/Z3.md
@@ -28,8 +28,7 @@ There are bindings for .NET, C, C++, Java, OCaml, Python, Julia and Web Assembly
 https://github.com/Z3Prover/z3
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-03 Dec 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 April 2015

--- a/Tools/Solvers/SMT/cvc5.md
+++ b/Tools/Solvers/SMT/cvc5.md
@@ -27,8 +27,7 @@ Repository: https://github.com/cvc5/cvc5
 Project page: https://cvc5.github.io/
 
 #### Last commit date:
-26 February 2023 (default branch)
-26 February 2023 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 2022

--- a/Tools/Solvers/SMT/dReal.md
+++ b/Tools/Solvers/SMT/dReal.md
@@ -30,8 +30,7 @@ Repository: https://github.com/dreal/dreal4/
 Collection of related repositories: https://github.com/dreal/
 
 #### Last commit date:
-17 Sep 2022 (default branch)
-08 Nov 2022 (last activity)
+dreal/dreal4: 19 Feb 2023 (last activity)
 
 #### Last publication date:
 18 July 2018

--- a/Tools/Solvers/UWrMaxSat.md
+++ b/Tools/Solvers/UWrMaxSat.md
@@ -32,8 +32,7 @@ This was created as an extension of [MiniSat+](MiniSat+.md). It was extended suc
 Repository: https://github.com/marekpiotrow/UWrMaxSat
 
 #### Last commit date:
-28 Sep 2022 (default branch)
-28 Sep 2022 (last activity)
+18 Mar 2023 (last activity)
 
 #### Last publication date:
 November 2020

--- a/Tools/Solvers/cvc4sy.md
+++ b/Tools/Solvers/cvc4sy.md
@@ -28,7 +28,6 @@ This solver specifically aims to prove unsatisfiability of formulae like: $\fora
 CVC4 repository: https://github.com/CVC4/CVC4-archived/
 
 #### Last commit date:
-05 May 2021 (default branch)
 06 May 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Solvers/µZ.md
+++ b/Tools/Solvers/µZ.md
@@ -33,8 +33,7 @@ Part of [Z3](SMT/Z3.md)
 Repository of [Z3](SMT/Z3.md) (µZ is part of this tool): https://github.com/Z3Prover/z3
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-03 Dec 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 2011

--- a/Tools/SpeAR.md
+++ b/Tools/SpeAR.md
@@ -27,6 +27,7 @@ Repository: https://github.com/lgwagner/SpeAR
 
 #### Last commit date:
 10 March 2021
+10 Mar 2021 (last activity)
 
 #### Last publication date:
 9 April 2017

--- a/Tools/Speculoos.md
+++ b/Tools/Speculoos.md
@@ -29,7 +29,6 @@ Given a basic language, it can generate [AIGER](../Formats/AIGER.md) files.
 Repository: https://github.com/romainbrenguier/Speculoos
 
 #### Last commit date:
-29 May 2017 (default branch)
 11 Jun 2017 (last activity)
 
 #### Last publication date:

--- a/Tools/Starling.md
+++ b/Tools/Starling.md
@@ -33,8 +33,7 @@ License: MIT
 Repository: https://github.com/septract/starling-tool
 
 #### Last commit date:
-07 Jun 2017 (default branch)
-21 Jul 2017 (last activity)
+02 Feb 2023 (last activity)
 
 #### Last publication date:
 13 July 2017

--- a/Tools/StringFuzz.md
+++ b/Tools/StringFuzz.md
@@ -40,7 +40,6 @@ Project page: http://stringfuzz.dmitryblotsky.com/
 Repository: https://github.com/dblotsky/stringfuzz
 
 #### Last commit date:
-11 Jun 2018 (default branch)
 17 Dec 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/SyMon.md
+++ b/Tools/SyMon.md
@@ -35,7 +35,6 @@ Repository: https://github.com/MasWag/symon
 Try online: https://colab.research.google.com/drive/17WNWuA3RxCA51xkDuVfOVeuUbRqHetDz
 
 #### Last commit date:
-08 Jun 2022 (default branch)
 17 Sep 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/SyNET.md
+++ b/Tools/SyNET.md
@@ -34,7 +34,6 @@ Project page: https://synet.ethz.ch/
 Repository: https://github.com/nsg-ethz/synet
 
 #### Last commit date:
-07 Dec 2017 (default branch)
 07 Dec 2017 (last activity)
 
 #### Last publication date:

--- a/Tools/Sylvan.md
+++ b/Tools/Sylvan.md
@@ -33,9 +33,8 @@ Mirror of repository: https://github.com/utwente-fmt/sylvan
 Documentation: https://trolando.github.io/sylvan/
 
 #### Last commit date:
-utwente-fmt/sylvan: 03 Sep 2022 (default branch)
-trolando/sylvan: 04 Sep 2022 (default branch)
-25 Sep 2022 (last activity)
+utwente-fmt/sylvan: 03 Sep 2022 (last activity)
+trolando/sylvan: 29 Mar 2023 (last activity)
 
 #### Last publication date:
 3 April 2019

--- a/Tools/Symbiotic.md
+++ b/Tools/Symbiotic.md
@@ -38,8 +38,7 @@ Repository: https://github.com/staticafi/symbiotic
 Project page: http://staticafi.github.io/symbiotic/
 
 #### Last commit date:
-30 Nov 2022 (default branch)
-02 Dec 2022 (last activity)
+23 Mar 2023 (last activity)
 
 #### Last publication date:
 18 May 2020

--- a/Tools/Symbolic Liveness Analysis.md
+++ b/Tools/Symbolic Liveness Analysis.md
@@ -30,14 +30,13 @@ Symbolic Liveness Analysis was implemented as an extension of [KLEE](KLEE.md). I
 Repository: https://github.com/COMSYS/SymbolicLivenessAnalysis
 
 #### Last commit date:
-15 Dec 2021 (default branch)
 16 Dec 2021 (last activity)
 
 #### Last publication date:
 18 July 2018
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-319-96142-2_27 (CAV '18)
+[Symbolic Liveness Analysis of Real-World Software](https://doi.org/10.1007/978-3-319-96142-2_27) (CAV '18)
 
 #### Related tools (tools mentioned or compared to in the paper):
 

--- a/Tools/Synduce.md
+++ b/Tools/Synduce.md
@@ -37,8 +37,7 @@ License: MIT
 Repository: https://github.com/synduce/Synduce
 
 #### Last commit date:
-02 Jun 2022 (default branch)
-29 Aug 2022 (last activity)
+01 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Synonym.md
+++ b/Tools/Synonym.md
@@ -37,7 +37,6 @@ Built on top of [[Descartes]]
 Repository: https://github.com/lmpick/synonym
 
 #### Last commit date:
-15 Dec 2018 (default branch)
 15 Dec 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/AMYTISS.md
+++ b/Tools/Synthesiser/AMYTISS.md
@@ -27,8 +27,7 @@ Tool for designing correct-by-construction controllers for large-scale discrete-
 https://github.com/mkhaled87/pFaces-AMYTISS
 
 #### Last commit date:
-26 Dec 2021 (default branch)
-26 Dec 2021 (last activity)
+10 Mar 2023 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/Synthesiser/BoSy.md
+++ b/Tools/Synthesiser/BoSy.md
@@ -31,7 +31,6 @@ Repository: https://github.com/reactive-systems/bosy
 Online interface: https://www.react.uni-saarland.de/tools/online/BoSy/
 
 #### Last commit date:
-21 Jul 2022 (default branch)
 21 Jul 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/BoSyHyper.md
+++ b/Tools/Synthesiser/BoSyHyper.md
@@ -31,7 +31,6 @@ https://www.react.uni-saarland.de/tools/bosy/
 https://github.com/reactive-systems/bosy
 
 #### Last commit date:
-21 Jul 2022 (default branch)
 21 Jul 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/DaPPer.md
+++ b/Tools/Synthesiser/DaPPer.md
@@ -31,7 +31,6 @@ It uses simulated annealing (SA) to synthesize PPL (probabilistic programming la
 Repository: https://github.com/schasins/PPL-synthesis
 
 #### Last commit date:
-21 Jan 2017 (default branch)
 21 Jan 2017 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/Escher.md
+++ b/Tools/Synthesiser/Escher.md
@@ -27,7 +27,6 @@ Given input-output examples, it synthesizes recursive programs implementing the 
 *Cannot find the original repository but someone else did make an implementation of the algorithm: https://github.com/MrVPlusOne/Escher-Scala*
 
 #### Last commit date:
-25 May 2017 (default branch)
 25 May 2017 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/FACTEST.md
+++ b/Tools/Synthesiser/FACTEST.md
@@ -42,7 +42,6 @@ Project page: https://kmmille.github.io/FACTEST/index.html
 Repository: https://github.com/kmmille/FACTEST
 
 #### Last commit date:
-01 Dec 2020 (default branch)
 01 Dec 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/FiMDP.md
+++ b/Tools/Synthesiser/FiMDP.md
@@ -33,8 +33,7 @@ Repository:
 https://github.com/FiMDP/FiMDP
 
 #### Last commit date:
-11 Nov 2021 (default branch)
-16 Aug 2022 (last activity)
+15 Feb 2023 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/Synthesiser/Hampa.md
+++ b/Tools/Synthesiser/Hampa.md
@@ -28,7 +28,6 @@ Uses [CVC4](../Solvers/SMT/CVC4.md).
 Artifact: https://github.com/XiaoLi0614/HampaAE
 
 #### Last commit date:
-22 Apr 2020 (default branch)
 22 Apr 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/JitSynth.md
+++ b/Tools/Synthesiser/JitSynth.md
@@ -29,7 +29,6 @@ Uses [[Rosette]]
 Repository: https://github.com/uw-unsat/jitsynth
 
 #### Last commit date:
-01 May 2020 (default branch)
 01 May 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/Manthan.md
+++ b/Tools/Synthesiser/Manthan.md
@@ -30,8 +30,7 @@ It uses [ABC](../Frameworks/ABC.md), [PicoSAT](../Solvers/SAT/PicoSAT.md), [[Ope
 Repository: https://github.com/meelgroup/manthan
 
 #### Last commit date:
-21 Jul 2022 (default branch)
-21 Jul 2022 (last activity)
+17 Feb 2023 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/Synthesiser/NIS.md
+++ b/Tools/Synthesiser/NIS.md
@@ -1,4 +1,3 @@
-
 #### Name:
 NIS (Numerical Invariant Synthesizer)
 

--- a/Tools/Synthesiser/PARTY.md
+++ b/Tools/Synthesiser/PARTY.md
@@ -38,7 +38,6 @@ If realisable, then an automaton in dot or [AIGER](../../Formats/AIGER.md) forma
 Repository: https://github.com/5nizza/party-elli
 
 #### Last commit date:
-12 Apr 2020 (default branch)
 12 Apr 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/PoS4MPC.md
+++ b/Tools/Synthesiser/PoS4MPC.md
@@ -1,4 +1,3 @@
-
 #### Name:
 PoS4MPC: Policy Synthesis for MPC
 
@@ -31,12 +30,13 @@ Uses [KLEE](../../Tools/KLEE.md) as symbolic execution engine.
 
 #### Last commit date:
 20 January 2022
+20 Jan 2022 (last activity)
 
 #### Last publication date:
 7 August 2022
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-031-13185-1 (CAV 2022)
+[Computer Aided Verification](https://doi.org/10.1007/978-3-031-13185-1) (CAV 2022)
 
 #### Related tools (tools mentioned or compared to in the paper):
 -

--- a/Tools/Synthesiser/RealSyn.md
+++ b/Tools/Synthesiser/RealSyn.md
@@ -41,7 +41,6 @@ Uses [Z3](../Solvers/SMT/Z3.md), [CVC4](../Solvers/SMT/CVC4.md), [Yices](../Solv
 Repository: https://github.com/umangm/realsyn
 
 #### Last commit date:
-28 Jun 2018 (default branch)
 28 Jun 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/SYNUDIC.md
+++ b/Tools/Synthesiser/SYNUDIC.md
@@ -33,7 +33,6 @@ SYNUDIC converts the input file into a (EF-)Yices formula or an exists SMT formu
 Repository: https://github.com/adriagascon/synudic
 
 #### Last commit date:
-21 Sep 2017 (default branch)
 21 Sep 2017 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/Strix.md
+++ b/Tools/Synthesiser/Strix.md
@@ -47,7 +47,6 @@ Repository: https://github.com/meyerphi/strix
 Online demo: https://meyerphi.github.io/strix-demo/
 
 #### Last commit date:
-16 Sep 2022 (default branch)
 16 Sep 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/SynPlexity.md
+++ b/Tools/Synthesiser/SynPlexity.md
@@ -36,7 +36,6 @@ License: MIT license
 Repository: https://github.com/Herbping/Synplexity
 
 #### Last commit date:
-27 May 2021 (default branch)
 27 May 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Synthesiser/syrup.md
+++ b/Tools/Synthesiser/syrup.md
@@ -39,9 +39,7 @@ Repository (of the backend): https://github.com/mariaschett/syrup-backend
 Repository for examples of the CAV '20 paper: https://github.com/mariaschett/syrup-backend/tree/master/examples/cav2020
 
 #### Last commit date:
-mariaschett/syrup-backend: 14 May 2020 (default branch)
-mariaschett/syrup-backend: 14 May 2020 (default branch)
-14 May 2020 (last activity)
+mariaschett/syrup-backend: 14 May 2020 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/T2.md
+++ b/Tools/T2.md
@@ -36,7 +36,6 @@ Uses [Z3](Solvers/SMT/Z3.md).
 Repository: https://github.com/mmjb/T2
 
 #### Last commit date:
-12 Feb 2018 (default branch)
 12 Feb 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/TChecker.md
+++ b/Tools/TChecker.md
@@ -36,8 +36,7 @@ License: MIT
 Repository: https://github.com/ticktac-project/tchecker
 
 #### Last commit date:
-24 Nov 2022 (default branch)
-24 Nov 2022 (last activity)
+20 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021
@@ -45,8 +44,8 @@ Repository: https://github.com/ticktac-project/tchecker
 #### List of related papers:
 [Certifying Emptiness of Timed Büchi Automata](https://doi.org/10.1007/978-3-030-57628-8_4) (FORMATS '20)
 [Why Liveness for Timed Automata Is Hard, and What We Can Do About It](https://doi.org/10.1145/3372310) (ACM Trans. on Computational Logic, Vol. 21, Iss. 3, '20)
-https://doi.org/10.1007/978-3-030-81685-8_30 (CAV '21, extends TChecker)
-https://doi.org/10.1007/978-3-030-25540-4_3 (CAV '19, extends TChecker)
+[Fast Zone-Based Algorithms for Reachability in Pushdown Timed Automata](https://doi.org/10.1007/978-3-030-81685-8_30) (CAV '21, extends TChecker)
+[Fast Algorithms for Handling Diagonal Constraints in Timed Automata](https://doi.org/10.1007/978-3-030-25540-4_3) (CAV '19, extends TChecker)
 
 #### Related tools (tools mentioned or compared to in the paper):
 [UPPAAL](Frameworks/UPPAAL.md)

--- a/Tools/TFML.md
+++ b/Tools/TFML.md
@@ -33,7 +33,6 @@ Project page: https://benjamin.farinier.org/cav2018/
 Repository: https://github.com/binsec/tfml
 
 #### Last commit date:
-17 Jul 2018 (default branch)
 27 Aug 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/TarTar.md
+++ b/Tools/TarTar.md
@@ -39,8 +39,7 @@ License: MIT
 Repository: https://github.com/sen-uni-kn/tartar
 
 #### Last commit date:
-02 May 2022 (default branch)
-02 May 2022 (last activity)
+09 Mar 2023 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/TcT.md
+++ b/Tools/TcT.md
@@ -42,7 +42,6 @@ Collection of repositories: https://github.com/ComputationWithBoundedResources
 Try online: http://colo6-c703.uibk.ac.at/tct/index.php
 
 #### Last commit date:
-16 Feb 2017 (last activity)
 
 #### Last publication date:
 9 April 2016

--- a/Tools/Termite.md
+++ b/Tools/Termite.md
@@ -26,7 +26,6 @@ Repository: https://github.com/termite-analyser/termite
 Demo/comparison: http://termite-analyser.github.io/results/results.html
 
 #### Last commit date:
-21 Apr 2018 (default branch)
 21 Apr 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/TheSy.md
+++ b/Tools/TheSy.md
@@ -32,8 +32,7 @@ License: GPL v3.0
 Repository: https://github.com/eytans/TheSy
 
 #### Last commit date:
-29 Apr 2021 (default branch)
-20 Nov 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Tinker.md
+++ b/Tools/Tinker.md
@@ -29,7 +29,6 @@ Project page: https://ggrov.github.io/tinker/
 Repository: https://github.com/ggrov/tinker
 
 #### Last commit date:
-05 Apr 2017 (default branch)
 13 Sep 2017 (last activity)
 
 #### Last publication date:

--- a/Tools/Trainify.md
+++ b/Tools/Trainify.md
@@ -1,4 +1,3 @@
-
 #### Name:
 Trainify
 
@@ -31,6 +30,7 @@ The tool builds a finite abstract state space using the trained neural network.
 
 #### Last commit date:
 16 June 2022
+16 Jun 2022 (last activity)
 
 #### Last publication date:
 7 August 2022

--- a/Tools/Typpete.md
+++ b/Tools/Typpete.md
@@ -31,7 +31,6 @@ Uses [Z3](Solvers/SMT/Z3.md).
 Repository: https://github.com/caterinaurban/Typpete
 
 #### Last commit date:
-06 Dec 2018 (default branch)
 12 Sep 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/Ultimate Automizer.md
+++ b/Tools/Ultimate Automizer.md
@@ -43,17 +43,17 @@ Try online: https://monteverdi.informatik.uni-freiburg.de/tomcat/Website/?ui=int
 Ultimate repository (Ultimate Automizer is a part of this): https://github.com/ultimate-pa/ultimate
 
 #### Last commit date:
-03 Dec 2022 (default branch)
-03 Dec 2022 (last activity)
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 14 April 2018
 
 #### List of related papers:
-https://doi.org/10.1007/978-3-319-89963-3_30 (TACAS '18)
-https://doi.org/10.1007/978-3-662-54580-5_30 (TACAS '17)
-https://doi.org/10.1007/978-3-662-49674-9_68 (TACAS '16)
-https://doi.org/10.1007/978-3-662-46681-0_43 (TACAS '15)
+[Ultimate Automizer and the Search for Perfect Interpolants](https://doi.org/10.1007/978-3-319-89963-3_30) (TACAS '18)
+[Ultimate Automizer with an On-Demand Construction of Floyd-Hoare Automata](https://doi.org/10.1007/978-3-662-54580-5_30) (TACAS '17)
+[Ultimate Automizer with Two-track Proofs](https://doi.org/10.1007/978-3-662-49674-9_68) (TACAS '16)
+[
+                Ultimate Automizer with Array Interpolation](https://doi.org/10.1007/978-3-662-46681-0_43) (TACAS '15)
 
 #### Related tools (tools mentioned or compared to in the paper):
 

--- a/Tools/Unique.md
+++ b/Tools/Unique.md
@@ -29,7 +29,6 @@ Uses [[ItpMiniSat]], a modified version of [[MiniSat]], bundled with the [[ExtAv
 https://github.com/fslivovsky/unique
 
 #### Last commit date:
-13 Sep 2022 (default branch)
 13 Sep 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/VIAP.md
+++ b/Tools/VIAP.md
@@ -32,7 +32,6 @@ SV-Comp: https://gitlab.com/sosy-lab/sv-comp/archives/-/blob/master/2018/viap.zi
 GitHub: https://github.com/VerifierIntegerAssignment/VIAP_ARRAY
 
 #### Last commit date:
-06 Apr 2019 (default branch)
 06 Apr 2019 (last activity)
 
 #### Last publication date:

--- a/Tools/VVT.md
+++ b/Tools/VVT.md
@@ -39,7 +39,6 @@ Project page: https://vvt.forsyte.at/
 Repository: https://github.com/hgoes/vvt
 
 #### Last commit date:
-08 Feb 2018 (default branch)
 09 Feb 2018 (last activity)
 
 #### Last publication date:

--- a/Tools/VerCors.md
+++ b/Tools/VerCors.md
@@ -35,6 +35,7 @@ Uses [Viper](Tools/Frameworks/Viper.md).
 
 #### Last commit date:
 16 February 2023
+30 Mar 2023 (last activity)
 
 #### Last publication date:
 17 October 2022

--- a/Tools/VeriAbs.md
+++ b/Tools/VeriAbs.md
@@ -35,7 +35,6 @@ SV-Comp'19: https://gitlab.com/sosy-lab/sv-comp/archives-2020/tree/master/2020/v
 GitHub: https://github.com/divyeshunadkat/VAJRA ([[VAJRA]] and [[TILER]] are integrated and are claimed as the source of success of VeriAbs at SV-Comp'20)
 
 #### Last commit date:
-20 Feb 2020 (default branch)
 20 Feb 2020 (last activity)
 
 #### Last publication date:

--- a/Tools/VeriQFair.md
+++ b/Tools/VeriQFair.md
@@ -1,4 +1,3 @@
-
 #### Name:
 VeriQFair
 
@@ -35,6 +34,7 @@ This tool can be used to compute the Lipschitz constant of a quantum decision mo
 
 #### Last commit date:
 4 June 2022
+04 Jun 2022 (last activity)
 
 #### Last publication date:
 6 August 2022

--- a/Tools/VerifAI.md
+++ b/Tools/VerifAI.md
@@ -49,8 +49,7 @@ Repository: https://github.com/BerkeleyLearnVerify/VerifAI
 Documentation: https://verifai.readthedocs.io/en/latest/
 
 #### Last commit date:
-02 Sep 2022 (default branch)
-30 Sep 2022 (last activity)
+09 Mar 2023 (last activity)
 
 #### Last publication date:
 12 July 2019

--- a/Tools/Verifast.md
+++ b/Tools/Verifast.md
@@ -36,8 +36,7 @@ Repository: https://github.com/verifast/verifast/
 Tutorial: https://doi.org/10.5281/zenodo.1068185
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Verisig.md
+++ b/Tools/Verisig.md
@@ -30,9 +30,8 @@ Repository: https://github.com/Verisig/verisig
 CAV '21 artifact: https://github.com/rivapp/CAV21_repeatability_package
 
 #### Last commit date:
-rivapp/CAV21_repeatability_package: 27 Apr 2021 (default branch)
-Verisig/verisig: 09 Jun 2021 (default branch)
-09 Jun 2021 (last activity)
+rivapp/CAV21_repeatability_package: 27 Apr 2021 (last activity)
+Verisig/verisig: 09 Jun 2021 (last activity)
 
 #### Last publication date:
 15 July 2021

--- a/Tools/Violat.md
+++ b/Tools/Violat.md
@@ -32,7 +32,6 @@ License: MIT
 Repository: https://github.com/michael-emmi/violat
 
 #### Last commit date:
-10 Apr 2022 (default branch)
 10 Apr 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/Weaver.md
+++ b/Tools/Weaver.md
@@ -36,7 +36,6 @@ Uses [Z3](Solvers/SMT/Z3.md),  [MathSAT](Solvers/SMT/MathSAT.md), [Yices](Solver
 Repository: https://github.com/weaver-verifier/weaver
 
 #### Last commit date:
-25 Feb 2021 (default branch)
 25 Feb 2021 (last activity)
 
 #### Last publication date:

--- a/Tools/Yosys.md
+++ b/Tools/Yosys.md
@@ -36,8 +36,7 @@ Repository: https://github.com/YosysHQ/yosys
 Project page: https://yosyshq.net/yosys/
 
 #### Last commit date:
-02 Dec 2022 (default branch)
-02 Dec 2022 (last activity)
+29 Mar 2023 (last activity)
 
 #### Last publication date:
 2019

--- a/Tools/cake_lpr.md
+++ b/Tools/cake_lpr.md
@@ -23,8 +23,7 @@ The same paper has a tool to convert PR to LPR
 Repository: https://github.com/tanyongkiam/cake_lpr
 
 #### Last commit date:
-01 Nov 2022 (default branch)
-01 Nov 2022 (last activity)
+18 Mar 2023 (last activity)
 
 #### Last publication date:
 Publication: conf/tacas/TanHM21

--- a/Tools/fault.md
+++ b/Tools/fault.md
@@ -29,8 +29,7 @@ Repository:
 https://github.com/leonardt/fault
 
 #### Last commit date:
-13 Oct 2022 (default branch)
-13 Oct 2022 (last activity)
+17 Feb 2023 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/iRankFinder.md
+++ b/Tools/iRankFinder.md
@@ -36,9 +36,8 @@ Repository?: https://github.com/costa-group/iRankFinder
 Repository (new implementation?): https://github.com/jesusjda/pyRankFinder
 
 #### Last commit date:
-jesusjda/pyRankFinder: 09 Oct 2020 (default branch)
-costa-group/iRankFinder: 18 Oct 2020 (default branch)
-18 Oct 2020 (last activity)
+jesusjda/pyRankFinder: 09 Oct 2020 (last activity)
+costa-group/iRankFinder: 21 Feb 2023 (last activity)
 
 #### Last publication date:
 13 July 2017

--- a/Tools/jcstress.md
+++ b/Tools/jcstress.md
@@ -31,8 +31,7 @@ Repository: https://github.com/openjdk/jcstress
 Project page: https://openjdk.java.net/projects/code-tools/jcstress/
 
 #### Last commit date:
-19 Oct 2022 (default branch)
-20 Nov 2022 (last activity)
+27 Feb 2023 (last activity)
 
 #### Last publication date:
 -

--- a/Tools/mlir-tv.md
+++ b/Tools/mlir-tv.md
@@ -1,4 +1,3 @@
-
 #### Name:
 mlir-tv
 
@@ -39,6 +38,7 @@ Uses [Z3](../../Tools/Solvers/SMT/Z3.md)
 
 #### Last commit date:
 24 October 2022
+15 Nov 2022 (last activity)
 
 #### Last publication date:
 6 August 2022

--- a/Tools/nnenum.md
+++ b/Tools/nnenum.md
@@ -31,8 +31,7 @@ nnenum focuses on the verification of fully-connected, feedforward neural networ
 Repository: https://github.com/stanleybak/nnenum
 
 #### Last commit date:
-02 Nov 2022 (default branch)
-02 Nov 2022 (last activity)
+27 Jan 2023 (last activity)
 
 #### Last publication date:
 14 July 2020

--- a/Tools/qtpi.md
+++ b/Tools/qtpi.md
@@ -38,8 +38,7 @@ Repository: https://github.com/mdxtoc/qtpi
 TACAS '20 artifact: https://doi.org/10.6084/m9.figshare.11882592
 
 #### Last commit date:
-23 Nov 2022 (default branch)
-23 Nov 2022 (last activity)
+08 Mar 2023 (last activity)
 
 #### Last publication date:
 17 April 2020

--- a/Tools/verifydtapn.md
+++ b/Tools/verifydtapn.md
@@ -24,8 +24,7 @@ License: BSD
 Repository: https://github.com/TAPAAL/verifydtapn
 
 #### Last commit date:
-10 Aug 2022 (default branch)
-10 Aug 2022 (last activity)
+01 Feb 2023 (last activity)
 
 #### Last publication date:
 16 August 2021

--- a/Tools/z3overlay.md
+++ b/Tools/z3overlay.md
@@ -20,7 +20,6 @@ an overlay to official binding to [[Z3]]
 https://github.com/termite-analyser/z3overlay
 
 #### Last commit date:
-18 Oct 2022 (default branch)
 18 Oct 2022 (last activity)
 
 #### Last publication date:

--- a/Tools/τ-DIGITS.md
+++ b/Tools/τ-DIGITS.md
@@ -41,7 +41,6 @@ License: MIT
 Repository: https://github.com/sedrews/digits
 
 #### Last commit date:
-14 Oct 2019 (default branch)
 14 Oct 2019 (last activity)
 
 #### Last publication date:


### PR DESCRIPTION
This adds paper titles where there was only a DOI and updates the last activity dates for repositories. The changes are all generated using ProVerBMate.

The 'last activity' date specifically looks at the pushed_at date that is returned by github for a repository. This corresponds to the last commit that was pushed to **any** of the repository's branches. This is different from what Yujie originally implemented which looked at the last commit on the default branch and the last activity (whether that was a push on the default branch or something else).

For some of the repositories this date may initially seem incorrect. For example, for ATHOS the date was updated to 28 April 2020, but there is no branch corresponding to this. However, it actually corresponds to the date when a branch was deleted. 